### PR TITLE
fix: scheduler supervisor command fails with permission denied

### DIFF
--- a/src/Docker/DockerGenerator.php
+++ b/src/Docker/DockerGenerator.php
@@ -677,7 +677,7 @@ CONF;
 ; Laravel Scheduler
 ; ===================
 [program:scheduler]
-command=/bin/sh -c "while true; do /usr/local/bin/php /var/www/html/artisan schedule:run --verbose --no-interaction >> /dev/stdout 2>&1; sleep 60; done"
+command=/bin/sh -c "while true; do /usr/local/bin/php /var/www/html/artisan schedule:run --verbose --no-interaction; sleep 60; done"
 user=www-data
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary

Fixes #27 - The scheduler supervisor program was silently failing with permission denied errors, preventing any scheduled jobs from running.

## Problem

The scheduler command in `DockerGenerator.php` used shell redirection:
```
>> /dev/stdout 2>&1
```

When running as `www-data` user, the shell cannot redirect to `/dev/stdout` in certain container configurations, causing:
```
/bin/sh: 1: cannot create /dev/stdout: Permission denied
```

## Fix

Remove the redundant redirect. Supervisor already captures stdout/stderr via:
```ini
stdout_logfile=/dev/stdout
stderr_logfile=/dev/stderr
```

## Impact

Any application using laravel-coolify with the scheduler enabled had a completely broken scheduler - jobs would never run. The container appeared healthy but the actual command failed silently every minute.

## Test plan

- [x] All 220 tests passing
- [ ] Deploy to test environment and verify scheduler runs

Stu Mason + AI <me@stumason.dev>