### PR TITLE
feat: Docker entrypoint for migrations and cache optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Database storage for resource configuration (`coolify_resources` table)
 - `CoolifyResource` Eloquent model with `getDefault()` helper
+- Docker entrypoint script for production deployments
+  - Runs `migrate --force` on container startup (fails deployment if migrations fail)
+  - Runs `php artisan optimize` (config, routes, views, events cache)
+  - Ensures storage link exists
 
 ### Changed
 - Resource UUIDs now stored in database instead of `.env` file
 - All commands read from database via `CoolifyResource::getDefault()`
 - `coolify:provision` saves to database instead of updating `.env`
+- Dockerfile now uses `ENTRYPOINT` instead of `CMD` for proper startup sequence
 
 ### Removed
 - `COOLIFY_APPLICATION_UUID`, `COOLIFY_SERVER_UUID`, `COOLIFY_PROJECT_UUID` env vars


### PR DESCRIPTION
## Summary

- Adds `docker/entrypoint.sh` that runs on container startup before supervisor
- Runs `migrate --force` with proper error handling - **deployment fails if migrations fail**
- Runs `php artisan optimize` (Laravel 12 gold standard for caching config, routes, views, events)
- Ensures storage link exists
- Changes Dockerfile from `CMD` to `ENTRYPOINT` for proper startup sequence

## Why

Previously, the generated Dockerfile didn't run migrations or cache optimization. Users had to:
- Manually configure Coolify pre-deployment commands
- Or miss out on production optimizations

Now it just works™ - every deployment automatically:
1. Runs migrations (with proper failure handling)
2. Caches all Laravel config/routes/views/events
3. Creates storage symlink

## Test plan

- [x] `composer test` - 222 tests passing
- [x] `composer lint` - clean
- [x] Regenerated Docker files in test app - verified entrypoint.sh content
- [x] Tested bash syntax validation

Stu Mason + AI <me@stumason.dev>