### PR TITLE
feat: add GitHub templates (CODEOWNERS, PR template, issue templates)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @StuMason

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,26 @@
+name: Bug Report
+description: Report something that's broken
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,20 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+
+## Changes
+
+-
+
+## Test plan
+
+- [ ] Tests added/updated
+- [ ] Manually tested locally
+
+## Checklist
+
+- [ ] Code follows project conventions
+- [ ] Documentation updated if needed


### PR DESCRIPTION
## Summary
- CODEOWNERS for automatic reviewer assignment
- Pull request template with checklist
- Issue templates for bugs and feature requests

## What's Included
- `.github/CODEOWNERS` - Assigns @StuMason as default reviewer
- `.github/PULL_REQUEST_TEMPLATE.md` - Standard PR checklist
- `.github/ISSUE_TEMPLATE/bug_report.yml` - Structured bug reports
- `.github/ISSUE_TEMPLATE/feature_request.yml` - Feature request template
- `.github/ISSUE_TEMPLATE/config.yml` - Enables blank issues

Stu Mason + AI <me@stumason.dev>