### PR TITLE
feat: Use COOLIFY_PROJECT_UUID as single source of truth for resource discovery

### DIFF
--- a/config/coolify.php
+++ b/config/coolify.php
@@ -43,6 +43,87 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Project UUID
+    |--------------------------------------------------------------------------
+    |
+    | The UUID of your Coolify project. This is the primary identifier used
+    | to discover all resources (applications, databases, services) within
+    | your project. Set this to enable automatic resource discovery.
+    |
+    | To find your project UUID:
+    | 1. Go to your Coolify dashboard
+    | 2. Navigate to your project
+    | 3. The UUID is in the URL: /projects/{uuid}
+    |
+    */
+
+    'project_uuid' => env('COOLIFY_PROJECT_UUID'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Environment Name
+    |--------------------------------------------------------------------------
+    |
+    | The name of the environment within your Coolify project. This is used
+    | to filter resources when discovering applications and databases.
+    | Common values: 'production', 'staging', 'development'
+    |
+    */
+
+    'environment' => env('COOLIFY_ENVIRONMENT', 'production'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Server UUID
+    |--------------------------------------------------------------------------
+    |
+    | The UUID of the Coolify server. If not set, it will be auto-discovered
+    | from your project's applications. Setting this explicitly can speed
+    | up provisioning operations.
+    |
+    */
+
+    'server_uuid' => env('COOLIFY_SERVER_UUID'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application UUID
+    |--------------------------------------------------------------------------
+    |
+    | The UUID of your primary application in Coolify. If not set, it will
+    | be auto-discovered as the first application in your environment.
+    | This is used by deploy, status, logs, and restart commands.
+    |
+    */
+
+    'application_uuid' => env('COOLIFY_APPLICATION_UUID'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Database UUID
+    |--------------------------------------------------------------------------
+    |
+    | The UUID of your primary database in Coolify. If not set, it will
+    | be auto-discovered from your environment (prefers PostgreSQL/MySQL).
+    |
+    */
+
+    'database_uuid' => env('COOLIFY_DATABASE_UUID'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Redis UUID
+    |--------------------------------------------------------------------------
+    |
+    | The UUID of your Redis/Dragonfly instance in Coolify. If not set,
+    | it will be auto-discovered from your environment.
+    |
+    */
+
+    'redis_uuid' => env('COOLIFY_REDIS_UUID'),
+
+    /*
+    |--------------------------------------------------------------------------
     | GitHub App UUID (Optional)
     |--------------------------------------------------------------------------
     |

--- a/routes/web.php
+++ b/routes/web.php
@@ -64,9 +64,9 @@ Route::middleware(Authenticate::class)->group(function () {
         Route::get('/teams/current', 'TeamController@current')->name('coolify.teams.current');
         Route::get('/teams/current/members', 'TeamController@members')->name('coolify.teams.members');
 
-        // Environment routes (configured resources)
+        // Environment routes (from project configuration)
         Route::get('/environments', 'EnvironmentController@index')->name('coolify.environments.index');
-        Route::post('/environments/{id}/switch', 'EnvironmentController@switch')->name('coolify.environments.switch');
+        Route::get('/environments/{name}', 'EnvironmentController@show')->name('coolify.environments.show');
     });
 
     // SPA catch-all - serves Vue app for all dashboard routes

--- a/src/Console/DeployCommand.php
+++ b/src/Console/DeployCommand.php
@@ -6,9 +6,9 @@ use Illuminate\Console\Command;
 use Stumason\Coolify\Console\Concerns\StreamsDeploymentLogs;
 use Stumason\Coolify\Contracts\ApplicationRepository;
 use Stumason\Coolify\Contracts\DeploymentRepository;
+use Stumason\Coolify\Coolify;
 use Stumason\Coolify\CoolifyClient;
 use Stumason\Coolify\Exceptions\CoolifyApiException;
-use Stumason\Coolify\Models\CoolifyResource;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Laravel\Prompts\confirm;
@@ -52,10 +52,10 @@ class DeployCommand extends Command
             return self::FAILURE;
         }
 
-        $uuid = $this->option('uuid') ?? CoolifyResource::getDefault()?->application_uuid;
+        $uuid = $this->option('uuid') ?? Coolify::applicationUuid();
 
         if (! $uuid) {
-            $this->components->error('No application configured. Run coolify:provision first or use --uuid option.');
+            $this->components->error('No application configured. Set COOLIFY_PROJECT_UUID or COOLIFY_APPLICATION_UUID in your .env file, or use --uuid option.');
 
             return self::FAILURE;
         }

--- a/src/Console/LogsCommand.php
+++ b/src/Console/LogsCommand.php
@@ -5,9 +5,9 @@ namespace Stumason\Coolify\Console;
 use Illuminate\Console\Command;
 use Stumason\Coolify\Contracts\ApplicationRepository;
 use Stumason\Coolify\Contracts\DeploymentRepository;
+use Stumason\Coolify\Coolify;
 use Stumason\Coolify\CoolifyClient;
 use Stumason\Coolify\Exceptions\CoolifyApiException;
-use Stumason\Coolify\Models\CoolifyResource;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'coolify:logs')]
@@ -60,10 +60,10 @@ class LogsCommand extends Command
      */
     protected function showApplicationLogs(ApplicationRepository $applications): int
     {
-        $uuid = $this->option('uuid') ?? CoolifyResource::getDefault()?->application_uuid;
+        $uuid = $this->option('uuid') ?? Coolify::applicationUuid();
 
         if (! $uuid) {
-            $this->components->error('No application configured. Run coolify:provision first or use --uuid option.');
+            $this->components->error('No application configured. Set COOLIFY_PROJECT_UUID or COOLIFY_APPLICATION_UUID in your .env file, or use --uuid option.');
 
             return self::FAILURE;
         }

--- a/src/Console/ProvisionCommand.php
+++ b/src/Console/ProvisionCommand.php
@@ -16,7 +16,6 @@ use Stumason\Coolify\Contracts\SecurityKeyRepository;
 use Stumason\Coolify\Contracts\ServerRepository;
 use Stumason\Coolify\CoolifyClient;
 use Stumason\Coolify\Exceptions\CoolifyApiException;
-use Stumason\Coolify\Models\CoolifyResource;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Laravel\Prompts\confirm;
@@ -357,27 +356,15 @@ class ProvisionCommand extends Command
                 $this->components->twoColumnDetail('  '.$cacheType, $redisUuid);
             }
 
-            // Save resource configuration to database
-            $resource = CoolifyResource::updateOrCreate(
-                ['name' => $appName],
-                [
-                    'server_uuid' => $serverUuid,
-                    'project_uuid' => $projectUuid,
-                    'environment' => $environment,
-                    'deploy_key_uuid' => $deployKey['uuid'],
-                    'repository' => $repoInfo['full_name'],
-                    'branch' => $branch,
-                    'application_uuid' => $appUuid,
-                    'database_uuid' => $dbUuid,
-                    'redis_uuid' => $redisUuid,
-                    'webhook_secret' => $this->webhookSecret,
-                ]
-            );
-            $resource->setAsDefault();
-
+            // Show local .env configuration for the user
             $this->newLine();
-            $this->line('  <fg=gray>Resource configuration saved to database</>');
-            $this->line('  <fg=gray>Database credentials set on Coolify application</>');
+            $this->line('  <fg=cyan;options=bold>LOCAL DEVELOPMENT CONFIG</>');
+            $this->line('  <fg=gray>Add to your local .env file to enable coolify commands:</>');
+            $this->newLine();
+            $this->line("  <fg=white>COOLIFY_PROJECT_UUID=</><fg=gray>{$projectUuid}</>");
+            $this->line("  <fg=white>COOLIFY_ENVIRONMENT=</><fg=gray>{$environment}</>");
+            $this->newLine();
+            $this->line('  <fg=gray>Or run:</> <fg=cyan>php artisan coolify:sync</>');
 
             // ─────────────────────────────────────────────────────────────────
             // DEPLOY KEY SETUP (with confirmation)

--- a/src/Console/RestartCommand.php
+++ b/src/Console/RestartCommand.php
@@ -4,9 +4,9 @@ namespace Stumason\Coolify\Console;
 
 use Illuminate\Console\Command;
 use Stumason\Coolify\Contracts\ApplicationRepository;
+use Stumason\Coolify\Coolify;
 use Stumason\Coolify\CoolifyClient;
 use Stumason\Coolify\Exceptions\CoolifyApiException;
-use Stumason\Coolify\Models\CoolifyResource;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Laravel\Prompts\confirm;
@@ -42,10 +42,10 @@ class RestartCommand extends Command
             return self::FAILURE;
         }
 
-        $uuid = $this->option('uuid') ?? CoolifyResource::getDefault()?->application_uuid;
+        $uuid = $this->option('uuid') ?? Coolify::applicationUuid();
 
         if (! $uuid) {
-            $this->components->error('No application configured. Run coolify:provision first or use --uuid option.');
+            $this->components->error('No application configured. Set COOLIFY_PROJECT_UUID or COOLIFY_APPLICATION_UUID in your .env file, or use --uuid option.');
 
             return self::FAILURE;
         }

--- a/src/Console/RollbackCommand.php
+++ b/src/Console/RollbackCommand.php
@@ -4,9 +4,9 @@ namespace Stumason\Coolify\Console;
 
 use Illuminate\Console\Command;
 use Stumason\Coolify\Contracts\DeploymentRepository;
+use Stumason\Coolify\Coolify;
 use Stumason\Coolify\CoolifyClient;
 use Stumason\Coolify\Exceptions\CoolifyApiException;
-use Stumason\Coolify\Models\CoolifyResource;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Laravel\Prompts\confirm;
@@ -44,10 +44,10 @@ class RollbackCommand extends Command
             return self::FAILURE;
         }
 
-        $applicationUuid = $this->option('uuid') ?? CoolifyResource::getDefault()?->application_uuid;
+        $applicationUuid = $this->option('uuid') ?? Coolify::applicationUuid();
 
         if (! $applicationUuid) {
-            $this->components->error('No application configured. Run coolify:provision first or use --uuid option.');
+            $this->components->error('No application configured. Set COOLIFY_PROJECT_UUID or COOLIFY_APPLICATION_UUID in your .env file, or use --uuid option.');
 
             return self::FAILURE;
         }

--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -5,9 +5,9 @@ namespace Stumason\Coolify\Console;
 use Illuminate\Console\Command;
 use Stumason\Coolify\Contracts\ApplicationRepository;
 use Stumason\Coolify\Contracts\DatabaseRepository;
+use Stumason\Coolify\Coolify;
 use Stumason\Coolify\CoolifyClient;
 use Stumason\Coolify\Exceptions\CoolifyApiException;
-use Stumason\Coolify\Models\CoolifyResource;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'coolify:status')]
@@ -118,10 +118,10 @@ class StatusCommand extends Command
      */
     protected function showApplicationStatus(ApplicationRepository $applications): int
     {
-        $uuid = $this->option('uuid') ?? CoolifyResource::getDefault()?->application_uuid;
+        $uuid = $this->option('uuid') ?? Coolify::applicationUuid();
 
         if (! $uuid) {
-            $this->components->error('No application configured. Run coolify:provision first or use --uuid option.');
+            $this->components->error('No application configured. Set COOLIFY_PROJECT_UUID or COOLIFY_APPLICATION_UUID in your .env file, or use --uuid option.');
 
             return self::FAILURE;
         }

--- a/src/Console/SyncCommand.php
+++ b/src/Console/SyncCommand.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace Stumason\Coolify\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Stumason\Coolify\Coolify;
+use Stumason\Coolify\CoolifyClient;
+use Stumason\Coolify\Exceptions\CoolifyApiException;
+use Stumason\Coolify\Services\CoolifyProjectService;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\spin;
+
+#[AsCommand(name: 'coolify:sync')]
+class SyncCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'coolify:sync
+                            {--write-env : Write discovered UUIDs to .env file}
+                            {--clear-cache : Clear cached project data}
+                            {--show : Show discovered resources without prompting}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Discover and sync Coolify project resources';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(CoolifyClient $client, CoolifyProjectService $projectService): int
+    {
+        if (! $client->isConfigured()) {
+            $this->components->error('Coolify is not configured. Please set COOLIFY_URL and COOLIFY_TOKEN in your .env file.');
+
+            return self::FAILURE;
+        }
+
+        // Test connection first
+        if (! $client->testConnection()) {
+            $this->components->error('Failed to connect to Coolify. Check your COOLIFY_URL and COOLIFY_TOKEN.');
+
+            return self::FAILURE;
+        }
+
+        // Clear cache if requested
+        if ($this->option('clear-cache')) {
+            $projectService->clearCache();
+            $this->components->info('Cache cleared.');
+
+            if (! $this->option('show') && ! $this->option('write-env')) {
+                return self::SUCCESS;
+            }
+        }
+
+        $this->newLine();
+        $this->components->info('Syncing Coolify Resources');
+
+        // Check if project UUID is configured
+        $projectUuid = $projectService->getProjectUuid();
+
+        if (! $projectUuid) {
+            // Help user discover their project UUID
+            return $this->discoverProject($client, $projectService);
+        }
+
+        // Show discovered resources
+        return $this->showResources($projectService);
+    }
+
+    /**
+     * Help user discover their project UUID.
+     */
+    protected function discoverProject(CoolifyClient $client, CoolifyProjectService $projectService): int
+    {
+        $this->components->warn('COOLIFY_PROJECT_UUID is not set.');
+        $this->newLine();
+
+        try {
+            // Fetch all projects
+            $projects = spin(
+                callback: fn () => Coolify::projects()->all(),
+                message: 'Fetching projects from Coolify...'
+            );
+
+            if (empty($projects)) {
+                $this->components->error('No projects found in your Coolify instance.');
+
+                return self::FAILURE;
+            }
+
+            // Let user select a project
+            $choices = collect($projects)->mapWithKeys(fn ($p) => [
+                $p['uuid'] => $p['name'].' ('.$p['uuid'].')',
+            ])->toArray();
+
+            $selectedUuid = select(
+                label: 'Select your project:',
+                options: $choices
+            );
+
+            $selectedProject = collect($projects)->firstWhere('uuid', $selectedUuid);
+
+            // Show environments for the selected project
+            $environments = spin(
+                callback: fn () => Coolify::projects()->environments($selectedUuid),
+                message: 'Fetching environments...'
+            );
+
+            $environmentName = 'production';
+            if (! empty($environments)) {
+                $envChoices = collect($environments)->mapWithKeys(fn ($e) => [
+                    $e['name'] => $e['name'],
+                ])->toArray();
+
+                if (count($envChoices) > 1) {
+                    $environmentName = select(
+                        label: 'Select environment:',
+                        options: $envChoices,
+                        default: isset($envChoices['production']) ? 'production' : array_key_first($envChoices)
+                    );
+                } else {
+                    $environmentName = array_key_first($envChoices) ?? 'production';
+                }
+            }
+
+            $this->newLine();
+            $this->line('  <fg=cyan;options=bold>Add these to your .env file:</>');
+            $this->newLine();
+            $this->line("  <fg=white>COOLIFY_PROJECT_UUID=</><fg=gray>{$selectedUuid}</>");
+            $this->line("  <fg=white>COOLIFY_ENVIRONMENT=</><fg=gray>{$environmentName}</>");
+            $this->newLine();
+
+            // Offer to write to .env
+            if ($this->option('write-env') || (! $this->option('no-interaction') && confirm('Write these values to your .env file?', default: true))) {
+                $this->writeToEnv([
+                    'COOLIFY_PROJECT_UUID' => $selectedUuid,
+                    'COOLIFY_ENVIRONMENT' => $environmentName,
+                ]);
+                $this->components->info('Values written to .env file.');
+                $this->newLine();
+                $this->line('  <fg=gray>Run</> <fg=cyan>php artisan coolify:sync --show</> <fg=gray>to see discovered resources.</>');
+            }
+
+            return self::SUCCESS;
+
+        } catch (CoolifyApiException $e) {
+            $this->components->error("Failed to fetch projects: {$e->getMessage()}");
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * Show discovered resources from the configured project.
+     */
+    protected function showResources(CoolifyProjectService $projectService): int
+    {
+        try {
+            $summary = spin(
+                callback: fn () => $projectService->getResourceSummary(),
+                message: 'Discovering resources...'
+            );
+
+            $this->newLine();
+            $this->line('  <fg=cyan;options=bold>PROJECT CONFIGURATION</>');
+            $this->components->twoColumnDetail('  Project UUID', $summary['project_uuid'] ?? 'N/A');
+            $this->components->twoColumnDetail('  Environment', $summary['environment'] ?? 'N/A');
+
+            $this->newLine();
+            $this->line('  <fg=cyan;options=bold>DISCOVERED RESOURCES</>');
+            $this->components->twoColumnDetail('  Application UUID', $summary['application_uuid'] ?? '<fg=yellow>Not found</>');
+            $this->components->twoColumnDetail('  Database UUID', $summary['database_uuid'] ?? '<fg=gray>Not found</>');
+            $this->components->twoColumnDetail('  Redis UUID', $summary['redis_uuid'] ?? '<fg=gray>Not found</>');
+            $this->components->twoColumnDetail('  Server UUID', $summary['server_uuid'] ?? '<fg=gray>Not found</>');
+
+            // Show applications
+            if (! empty($summary['applications'])) {
+                $this->newLine();
+                $this->line('  <fg=yellow>Applications:</>');
+                foreach ($summary['applications'] as $app) {
+                    $status = $this->formatStatus($app['status'] ?? 'unknown');
+                    $this->line("    • {$app['name']} ({$app['uuid']}) {$status}");
+                }
+            }
+
+            // Show databases
+            if (! empty($summary['databases'])) {
+                $this->newLine();
+                $this->line('  <fg=yellow>Databases:</>');
+                foreach ($summary['databases'] as $db) {
+                    $this->line("    • {$db['name']} ({$db['type']}) - {$db['uuid']}");
+                }
+            }
+
+            // Show services
+            if (! empty($summary['services'])) {
+                $this->newLine();
+                $this->line('  <fg=yellow>Services:</>');
+                foreach ($summary['services'] as $service) {
+                    $this->line("    • {$service['name']} - {$service['uuid']}");
+                }
+            }
+
+            // Offer to write explicit UUIDs to .env
+            if ($this->option('write-env') || (! $this->option('no-interaction') && ! $this->option('show') && confirm('Write discovered UUIDs to your .env file?', default: false))) {
+                $envVars = [];
+
+                if ($summary['application_uuid']) {
+                    $envVars['COOLIFY_APPLICATION_UUID'] = $summary['application_uuid'];
+                }
+                if ($summary['database_uuid']) {
+                    $envVars['COOLIFY_DATABASE_UUID'] = $summary['database_uuid'];
+                }
+                if ($summary['redis_uuid']) {
+                    $envVars['COOLIFY_REDIS_UUID'] = $summary['redis_uuid'];
+                }
+                if ($summary['server_uuid']) {
+                    $envVars['COOLIFY_SERVER_UUID'] = $summary['server_uuid'];
+                }
+
+                if (! empty($envVars)) {
+                    $this->writeToEnv($envVars);
+                    $this->newLine();
+                    $this->components->info('UUIDs written to .env file.');
+                }
+            }
+
+            $this->newLine();
+
+            return self::SUCCESS;
+
+        } catch (CoolifyApiException $e) {
+            $this->components->error("Failed to discover resources: {$e->getMessage()}");
+
+            return self::FAILURE;
+        }
+    }
+
+    /**
+     * Format status with color indicator.
+     */
+    protected function formatStatus(string $status): string
+    {
+        return match (strtolower($status)) {
+            'running' => '<fg=green>● running</>',
+            'stopped' => '<fg=red>● stopped</>',
+            'starting' => '<fg=yellow>● starting</>',
+            'restarting' => '<fg=yellow>● restarting</>',
+            'deploying' => '<fg=blue>● deploying</>',
+            default => "<fg=gray>● {$status}</>",
+        };
+    }
+
+    /**
+     * Write key-value pairs to the .env file.
+     *
+     * @param  array<string, string>  $values
+     */
+    protected function writeToEnv(array $values): void
+    {
+        $envPath = base_path('.env');
+
+        if (! File::exists($envPath)) {
+            // Create .env from .env.example if it exists
+            $examplePath = base_path('.env.example');
+            if (File::exists($examplePath)) {
+                File::copy($examplePath, $envPath);
+            } else {
+                File::put($envPath, '');
+            }
+        }
+
+        $content = File::get($envPath);
+
+        foreach ($values as $key => $value) {
+            // Check if key already exists
+            if (preg_match("/^{$key}=.*/m", $content)) {
+                // Update existing value
+                $content = preg_replace("/^{$key}=.*/m", "{$key}={$value}", $content);
+            } else {
+                // Add new value at the end
+                $content = rtrim($content)."\n{$key}={$value}\n";
+            }
+        }
+
+        File::put($envPath, $content);
+    }
+}

--- a/src/Coolify.php
+++ b/src/Coolify.php
@@ -9,7 +9,7 @@ use Stumason\Coolify\Contracts\DeploymentRepository;
 use Stumason\Coolify\Contracts\ProjectRepository;
 use Stumason\Coolify\Contracts\ServerRepository;
 use Stumason\Coolify\Contracts\ServiceRepository;
-use Stumason\Coolify\Models\CoolifyResource;
+use Stumason\Coolify\Services\CoolifyProjectService;
 
 class Coolify
 {
@@ -46,6 +46,14 @@ class Coolify
         static::$authUsing = $callback;
 
         return new self;
+    }
+
+    /**
+     * Get the project service instance for resource discovery.
+     */
+    public static function project(): CoolifyProjectService
+    {
+        return app(CoolifyProjectService::class);
     }
 
     /**
@@ -97,11 +105,38 @@ class Coolify
     }
 
     /**
+     * Get the default application UUID.
+     *
+     * This uses the CoolifyProjectService to discover the application UUID
+     * from COOLIFY_PROJECT_UUID or COOLIFY_APPLICATION_UUID config.
+     */
+    public static function applicationUuid(): ?string
+    {
+        return static::project()->getApplicationUuid();
+    }
+
+    /**
+     * Get the default database UUID.
+     */
+    public static function databaseUuid(): ?string
+    {
+        return static::project()->getDatabaseUuid();
+    }
+
+    /**
+     * Get the default Redis UUID.
+     */
+    public static function redisUuid(): ?string
+    {
+        return static::project()->getRedisUuid();
+    }
+
+    /**
      * Deploy the current application.
      */
     public static function deploy(?string $uuid = null): array
     {
-        $uuid = $uuid ?? CoolifyResource::getDefault()?->application_uuid;
+        $uuid = $uuid ?? static::applicationUuid();
 
         return static::applications()->deploy($uuid);
     }
@@ -111,7 +146,7 @@ class Coolify
      */
     public static function status(?string $uuid = null): array
     {
-        $uuid = $uuid ?? CoolifyResource::getDefault()?->application_uuid;
+        $uuid = $uuid ?? static::applicationUuid();
 
         return static::applications()->get($uuid);
     }
@@ -121,7 +156,7 @@ class Coolify
      */
     public static function logs(?string $uuid = null): array
     {
-        $uuid = $uuid ?? CoolifyResource::getDefault()?->application_uuid;
+        $uuid = $uuid ?? static::applicationUuid();
 
         return static::applications()->logs($uuid);
     }

--- a/src/CoolifyServiceProvider.php
+++ b/src/CoolifyServiceProvider.php
@@ -111,6 +111,7 @@ class CoolifyServiceProvider extends ServiceProvider
                 Console\RollbackCommand::class,
                 Console\SetupCiCommand::class,
                 Console\StatusCommand::class,
+                Console\SyncCommand::class,
             ]);
         }
     }

--- a/src/ServiceBindings.php
+++ b/src/ServiceBindings.php
@@ -20,6 +20,7 @@ use Stumason\Coolify\Repositories\CoolifySecurityKeyRepository;
 use Stumason\Coolify\Repositories\CoolifyServerRepository;
 use Stumason\Coolify\Repositories\CoolifyServiceRepository;
 use Stumason\Coolify\Repositories\CoolifyTeamRepository;
+use Stumason\Coolify\Services\CoolifyProjectService;
 
 trait ServiceBindings
 {
@@ -39,5 +40,8 @@ trait ServiceBindings
         ServerRepository::class => CoolifyServerRepository::class,
         ServiceRepository::class => CoolifyServiceRepository::class,
         TeamRepository::class => CoolifyTeamRepository::class,
+
+        // Service bindings
+        CoolifyProjectService::class => CoolifyProjectService::class,
     ];
 }

--- a/src/Services/CoolifyProjectService.php
+++ b/src/Services/CoolifyProjectService.php
@@ -1,0 +1,338 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stumason\Coolify\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Stumason\Coolify\Contracts\ProjectRepository;
+use Stumason\Coolify\Exceptions\CoolifyApiException;
+
+/**
+ * Service for discovering and caching Coolify project resources.
+ *
+ * Uses COOLIFY_PROJECT_UUID as the single source of truth, then fetches
+ * environments and resources from the Coolify API on-demand with caching.
+ */
+class CoolifyProjectService
+{
+    /**
+     * Cache key prefix for project data.
+     */
+    protected const CACHE_PREFIX = 'coolify:project:';
+
+    public function __construct(
+        protected ProjectRepository $projects
+    ) {}
+
+    /**
+     * Get the configured project UUID.
+     */
+    public function getProjectUuid(): ?string
+    {
+        return config('coolify.project_uuid');
+    }
+
+    /**
+     * Get the configured environment name.
+     */
+    public function getEnvironment(): string
+    {
+        return config('coolify.environment', 'production');
+    }
+
+    /**
+     * Get project details.
+     */
+    public function getProject(): ?array
+    {
+        $projectUuid = $this->getProjectUuid();
+
+        if (! $projectUuid) {
+            return null;
+        }
+
+        return $this->cached("project:{$projectUuid}", function () use ($projectUuid) {
+            return $this->projects->get($projectUuid);
+        });
+    }
+
+    /**
+     * Get all environments for the configured project.
+     */
+    public function getEnvironments(): array
+    {
+        $projectUuid = $this->getProjectUuid();
+
+        if (! $projectUuid) {
+            return [];
+        }
+
+        return $this->cached("environments:{$projectUuid}", function () use ($projectUuid) {
+            return $this->projects->environments($projectUuid);
+        });
+    }
+
+    /**
+     * Get the current environment's resources.
+     */
+    public function getCurrentEnvironment(): ?array
+    {
+        $projectUuid = $this->getProjectUuid();
+        $environment = $this->getEnvironment();
+
+        if (! $projectUuid) {
+            return null;
+        }
+
+        return $this->cached("environment:{$projectUuid}:{$environment}", function () use ($projectUuid, $environment) {
+            try {
+                return $this->projects->environment($projectUuid, $environment);
+            } catch (CoolifyApiException) {
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Get all applications in the current environment.
+     */
+    public function getApplications(): array
+    {
+        $environment = $this->getCurrentEnvironment();
+
+        if (! $environment) {
+            return [];
+        }
+
+        return $environment['applications'] ?? [];
+    }
+
+    /**
+     * Get all databases in the current environment.
+     */
+    public function getDatabases(): array
+    {
+        $environment = $this->getCurrentEnvironment();
+
+        if (! $environment) {
+            return [];
+        }
+
+        // Coolify returns different types of databases
+        $databases = [];
+
+        foreach (['postgresqls', 'mysqls', 'mariadbs', 'mongodbs', 'redis', 'dragonflies', 'keydbs', 'clickhouses'] as $type) {
+            if (! empty($environment[$type])) {
+                foreach ($environment[$type] as $db) {
+                    $db['_type'] = $type;
+                    $databases[] = $db;
+                }
+            }
+        }
+
+        return $databases;
+    }
+
+    /**
+     * Get all services in the current environment.
+     */
+    public function getServices(): array
+    {
+        $environment = $this->getCurrentEnvironment();
+
+        if (! $environment) {
+            return [];
+        }
+
+        return $environment['services'] ?? [];
+    }
+
+    /**
+     * Get the default application UUID.
+     *
+     * Priority:
+     * 1. COOLIFY_APPLICATION_UUID env var
+     * 2. First application in the environment
+     */
+    public function getApplicationUuid(): ?string
+    {
+        // Check for explicit config first
+        $configuredUuid = config('coolify.application_uuid');
+        if ($configuredUuid) {
+            return $configuredUuid;
+        }
+
+        // Fall back to discovering from project
+        $applications = $this->getApplications();
+
+        return $applications[0]['uuid'] ?? null;
+    }
+
+    /**
+     * Get a specific application by UUID or name.
+     */
+    public function getApplication(?string $identifier = null): ?array
+    {
+        if (! $identifier) {
+            $identifier = $this->getApplicationUuid();
+        }
+
+        if (! $identifier) {
+            return null;
+        }
+
+        $applications = $this->getApplications();
+
+        foreach ($applications as $app) {
+            if (($app['uuid'] ?? null) === $identifier || ($app['name'] ?? null) === $identifier) {
+                return $app;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the default database UUID.
+     *
+     * Priority:
+     * 1. COOLIFY_DATABASE_UUID env var
+     * 2. First PostgreSQL/MySQL database in the environment
+     */
+    public function getDatabaseUuid(): ?string
+    {
+        // Check for explicit config first
+        $configuredUuid = config('coolify.database_uuid');
+        if ($configuredUuid) {
+            return $configuredUuid;
+        }
+
+        // Fall back to discovering from project
+        $databases = $this->getDatabases();
+
+        // Prefer PostgreSQL, then MySQL
+        foreach ($databases as $db) {
+            $type = $db['_type'] ?? '';
+            if (in_array($type, ['postgresqls', 'mysqls', 'mariadbs'])) {
+                return $db['uuid'] ?? null;
+            }
+        }
+
+        return $databases[0]['uuid'] ?? null;
+    }
+
+    /**
+     * Get the default Redis/Dragonfly UUID.
+     *
+     * Priority:
+     * 1. COOLIFY_REDIS_UUID env var
+     * 2. First Redis/Dragonfly in the environment
+     */
+    public function getRedisUuid(): ?string
+    {
+        // Check for explicit config first
+        $configuredUuid = config('coolify.redis_uuid');
+        if ($configuredUuid) {
+            return $configuredUuid;
+        }
+
+        // Fall back to discovering from project
+        $databases = $this->getDatabases();
+
+        foreach ($databases as $db) {
+            $type = $db['_type'] ?? '';
+            if (in_array($type, ['redis', 'dragonflies', 'keydbs'])) {
+                return $db['uuid'] ?? null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the server UUID from the configured project.
+     */
+    public function getServerUuid(): ?string
+    {
+        // Check for explicit config first
+        $configuredUuid = config('coolify.server_uuid');
+        if ($configuredUuid) {
+            return $configuredUuid;
+        }
+
+        // Try to get from an application
+        $app = $this->getApplication();
+        if ($app && isset($app['destination']['server']['uuid'])) {
+            return $app['destination']['server']['uuid'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if the project is configured.
+     */
+    public function isConfigured(): bool
+    {
+        return $this->getProjectUuid() !== null;
+    }
+
+    /**
+     * Clear all cached project data.
+     */
+    public function clearCache(): void
+    {
+        $projectUuid = $this->getProjectUuid();
+        $environment = $this->getEnvironment();
+
+        if ($projectUuid) {
+            Cache::forget(self::CACHE_PREFIX."project:{$projectUuid}");
+            Cache::forget(self::CACHE_PREFIX."environments:{$projectUuid}");
+            Cache::forget(self::CACHE_PREFIX."environment:{$projectUuid}:{$environment}");
+        }
+    }
+
+    /**
+     * Get or cache a value.
+     */
+    protected function cached(string $key, callable $callback): mixed
+    {
+        $ttl = config('coolify.cache_ttl', 30);
+
+        if ($ttl <= 0) {
+            return $callback();
+        }
+
+        return Cache::remember(self::CACHE_PREFIX.$key, $ttl, $callback);
+    }
+
+    /**
+     * Get all discovered resources as a summary.
+     */
+    public function getResourceSummary(): array
+    {
+        return [
+            'project_uuid' => $this->getProjectUuid(),
+            'environment' => $this->getEnvironment(),
+            'application_uuid' => $this->getApplicationUuid(),
+            'database_uuid' => $this->getDatabaseUuid(),
+            'redis_uuid' => $this->getRedisUuid(),
+            'server_uuid' => $this->getServerUuid(),
+            'applications' => array_map(fn ($a) => [
+                'uuid' => $a['uuid'] ?? null,
+                'name' => $a['name'] ?? null,
+                'status' => $a['status'] ?? null,
+            ], $this->getApplications()),
+            'databases' => array_map(fn ($d) => [
+                'uuid' => $d['uuid'] ?? null,
+                'name' => $d['name'] ?? null,
+                'type' => $d['_type'] ?? null,
+            ], $this->getDatabases()),
+            'services' => array_map(fn ($s) => [
+                'uuid' => $s['uuid'] ?? null,
+                'name' => $s['name'] ?? null,
+            ], $this->getServices()),
+        ];
+    }
+}

--- a/tests/Feature/Console/DeployCommandTest.php
+++ b/tests/Feature/Console/DeployCommandTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
-use Stumason\Coolify\Models\CoolifyResource;
 
 beforeEach(function () {
     Http::preventStrayRequests();
@@ -17,8 +16,11 @@ describe('coolify:deploy command', function () {
     });
 
     it('shows error when no application UUID', function () {
-        // Clear the default resource so no application UUID exists
-        CoolifyResource::query()->delete();
+        // Clear the application UUID config so no application UUID exists
+        config([
+            'coolify.application_uuid' => null,
+            'coolify.project_uuid' => null,
+        ]);
 
         $this->artisan('coolify:deploy', ['--force' => true])
             ->assertFailed()

--- a/tests/Feature/Console/StatusCommandTest.php
+++ b/tests/Feature/Console/StatusCommandTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Support\Facades\Http;
-use Stumason\Coolify\Models\CoolifyResource;
 
 beforeEach(function () {
     Http::preventStrayRequests();
@@ -17,8 +16,11 @@ describe('coolify:status command', function () {
     });
 
     it('shows error when no application UUID', function () {
-        // Clear the default resource so no application UUID exists
-        CoolifyResource::query()->delete();
+        // Clear the application UUID config so no application UUID exists
+        config([
+            'coolify.application_uuid' => null,
+            'coolify.project_uuid' => null,
+        ]);
 
         Http::fake(['*' => Http::response(['version' => '4.0'], 200)]);
 

--- a/tests/Feature/Http/EnvironmentControllerTest.php
+++ b/tests/Feature/Http/EnvironmentControllerTest.php
@@ -2,86 +2,63 @@
 
 use Illuminate\Support\Facades\Http;
 use Stumason\Coolify\Coolify;
-use Stumason\Coolify\Models\CoolifyResource;
 
 beforeEach(function () {
     Http::preventStrayRequests();
     Coolify::auth(fn () => true);
-
-    // Clean up any existing resources
-    CoolifyResource::query()->delete();
 });
 
 describe('EnvironmentController', function () {
-    it('lists all configured environments', function () {
-        CoolifyResource::create([
-            'name' => 'Production',
-            'environment' => 'production',
-            'server_uuid' => 'server-1',
-            'project_uuid' => 'project-1',
-            'application_uuid' => 'app-prod',
-            'is_default' => true,
-        ]);
-
-        CoolifyResource::create([
-            'name' => 'Staging',
-            'environment' => 'staging',
-            'server_uuid' => 'server-1',
-            'project_uuid' => 'project-1',
-            'application_uuid' => 'app-staging',
-            'is_default' => false,
+    it('lists environments from project', function () {
+        Http::fake([
+            '*/projects/test-project-uuid/environments' => Http::response([
+                ['id' => 1, 'name' => 'production', 'description' => 'Production environment'],
+                ['id' => 2, 'name' => 'staging', 'description' => 'Staging environment'],
+            ], 200),
         ]);
 
         $response = $this->getJson(route('coolify.environments.index'));
 
         $response->assertOk()
             ->assertJsonCount(2)
-            ->assertJsonFragment(['name' => 'Production', 'is_default' => true])
-            ->assertJsonFragment(['name' => 'Staging', 'is_default' => false]);
+            ->assertJsonFragment(['name' => 'production', 'is_default' => true])
+            ->assertJsonFragment(['name' => 'staging', 'is_default' => false]);
     });
 
-    it('switches to a different environment', function () {
-        $prod = CoolifyResource::create([
-            'name' => 'Production',
-            'environment' => 'production',
-            'server_uuid' => 'server-1',
-            'project_uuid' => 'project-1',
-            'application_uuid' => 'app-prod',
-            'is_default' => true,
+    it('shows specific environment details', function () {
+        Http::fake([
+            '*/projects/test-project-uuid/staging' => Http::response([
+                'name' => 'staging',
+                'applications' => [
+                    ['uuid' => 'app-1', 'name' => 'My Staging App'],
+                ],
+            ], 200),
         ]);
 
-        $staging = CoolifyResource::create([
-            'name' => 'Staging',
-            'environment' => 'staging',
-            'server_uuid' => 'server-1',
-            'project_uuid' => 'project-1',
-            'application_uuid' => 'app-staging',
-            'is_default' => false,
-        ]);
-
-        $response = $this->postJson(route('coolify.environments.switch', $staging->id));
+        $response = $this->getJson(route('coolify.environments.show', 'staging'));
 
         $response->assertOk()
             ->assertJson([
                 'success' => true,
-                'message' => 'Switched to Staging',
             ]);
-
-        // Verify the switch happened
-        expect(CoolifyResource::find($staging->id)->is_default)->toBeTrue();
-        expect(CoolifyResource::find($prod->id)->is_default)->toBeFalse();
     });
 
-    it('returns 404 for non-existent environment', function () {
-        $response = $this->postJson(route('coolify.environments.switch', 999));
+    it('returns empty array when project not configured', function () {
+        config(['coolify.project_uuid' => null]);
 
-        $response->assertNotFound();
-    });
-
-    it('returns empty array when no environments configured', function () {
         $response = $this->getJson(route('coolify.environments.index'));
 
         $response->assertOk()
             ->assertJsonCount(0);
+    });
+
+    it('returns 404 for non-existent environment', function () {
+        Http::fake([
+            '*/projects/test-project-uuid/nonexistent' => Http::response(['message' => 'Not found'], 404),
+        ]);
+
+        $response = $this->getJson(route('coolify.environments.show', 'nonexistent'));
+
+        $response->assertNotFound();
     });
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,10 +2,8 @@
 
 namespace Stumason\Coolify\Tests;
 
-use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use Stumason\Coolify\CoolifyServiceProvider;
-use Stumason\Coolify\Models\CoolifyResource;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -45,7 +43,7 @@ abstract class TestCase extends BaseTestCase
         // Set encryption key for testing
         $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
 
-        // Use SQLite in-memory database for testing
+        // Use SQLite in-memory database for testing (still needed for Laravel internals)
         $app['config']->set('database.default', 'testing');
         $app['config']->set('database.connections.testing', [
             'driver' => 'sqlite',
@@ -57,58 +55,13 @@ abstract class TestCase extends BaseTestCase
         $app['config']->set('coolify.url', 'https://coolify.test');
         $app['config']->set('coolify.token', 'test-token');
         $app['config']->set('coolify.cache_ttl', 0);
-    }
 
-    /**
-     * Set up the test case.
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        // Create table if not exists
-        if (! Schema::hasTable('coolify_resources')) {
-            Schema::create('coolify_resources', function ($table) {
-                $table->id();
-                $table->string('name')->unique();
-                $table->string('server_uuid');
-                $table->string('project_uuid');
-                $table->string('environment')->default('production');
-                $table->string('deploy_key_uuid')->nullable();
-                $table->string('repository')->nullable();
-                $table->string('branch')->nullable();
-                $table->string('application_uuid')->nullable();
-                $table->string('database_uuid')->nullable();
-                $table->string('redis_uuid')->nullable();
-                $table->boolean('is_default')->default(false)->index();
-                $table->json('metadata')->nullable();
-                $table->timestamps();
-            });
-        }
-
-        // Create default test resource
-        $this->createDefaultResource();
-    }
-
-    /**
-     * Create a default CoolifyResource for testing.
-     */
-    protected function createDefaultResource(): CoolifyResource
-    {
-        return CoolifyResource::updateOrCreate(
-            ['name' => 'test-app'],
-            [
-                'server_uuid' => 'test-server-uuid',
-                'project_uuid' => 'test-project-uuid',
-                'environment' => 'production',
-                'deploy_key_uuid' => 'test-deploy-key-uuid',
-                'repository' => 'test/repo',
-                'branch' => 'main',
-                'application_uuid' => 'test-app-uuid',
-                'database_uuid' => 'test-db-uuid',
-                'redis_uuid' => 'test-redis-uuid',
-                'is_default' => true,
-            ]
-        );
+        // Default resource UUIDs for testing (no database dependency)
+        $app['config']->set('coolify.project_uuid', 'test-project-uuid');
+        $app['config']->set('coolify.environment', 'production');
+        $app['config']->set('coolify.server_uuid', 'test-server-uuid');
+        $app['config']->set('coolify.application_uuid', 'test-app-uuid');
+        $app['config']->set('coolify.database_uuid', 'test-db-uuid');
+        $app['config']->set('coolify.redis_uuid', 'test-redis-uuid');
     }
 }

--- a/tests/Unit/Services/CoolifyProjectServiceTest.php
+++ b/tests/Unit/Services/CoolifyProjectServiceTest.php
@@ -1,0 +1,220 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Stumason\Coolify\Services\CoolifyProjectService;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+    Cache::flush();
+});
+
+describe('CoolifyProjectService', function () {
+    it('returns null when project UUID is not configured', function () {
+        config([
+            'coolify.project_uuid' => null,
+            'coolify.application_uuid' => null,
+        ]);
+
+        $service = app(CoolifyProjectService::class);
+
+        expect($service->getProjectUuid())->toBeNull()
+            ->and($service->isConfigured())->toBeFalse()
+            ->and($service->getApplicationUuid())->toBeNull();
+    });
+
+    it('returns configured project UUID', function () {
+        config(['coolify.project_uuid' => 'test-project-uuid']);
+
+        $service = app(CoolifyProjectService::class);
+
+        expect($service->getProjectUuid())->toBe('test-project-uuid')
+            ->and($service->isConfigured())->toBeTrue();
+    });
+
+    it('returns configured application UUID directly', function () {
+        config([
+            'coolify.project_uuid' => null,
+            'coolify.application_uuid' => 'direct-app-uuid',
+        ]);
+
+        $service = app(CoolifyProjectService::class);
+
+        expect($service->getApplicationUuid())->toBe('direct-app-uuid');
+    });
+
+    it('returns configured database UUID directly', function () {
+        config([
+            'coolify.project_uuid' => null,
+            'coolify.database_uuid' => 'direct-db-uuid',
+        ]);
+
+        $service = app(CoolifyProjectService::class);
+
+        expect($service->getDatabaseUuid())->toBe('direct-db-uuid');
+    });
+
+    it('returns configured redis UUID directly', function () {
+        config([
+            'coolify.project_uuid' => null,
+            'coolify.redis_uuid' => 'direct-redis-uuid',
+        ]);
+
+        $service = app(CoolifyProjectService::class);
+
+        expect($service->getRedisUuid())->toBe('direct-redis-uuid');
+    });
+
+    it('discovers application UUID from project environment', function () {
+        config([
+            'coolify.project_uuid' => 'test-project-uuid',
+            'coolify.environment' => 'production',
+            'coolify.application_uuid' => null,
+        ]);
+
+        Http::fake([
+            '*/projects/test-project-uuid/production' => Http::response([
+                'applications' => [
+                    ['uuid' => 'discovered-app-uuid', 'name' => 'My App'],
+                ],
+                'postgresqls' => [],
+                'redis' => [],
+            ], 200),
+        ]);
+
+        $service = app(CoolifyProjectService::class);
+
+        expect($service->getApplicationUuid())->toBe('discovered-app-uuid');
+    });
+
+    it('discovers database UUID from project environment', function () {
+        config([
+            'coolify.project_uuid' => 'test-project-uuid',
+            'coolify.environment' => 'production',
+            'coolify.database_uuid' => null,
+        ]);
+
+        Http::fake([
+            '*/projects/test-project-uuid/production' => Http::response([
+                'applications' => [],
+                'postgresqls' => [
+                    ['uuid' => 'discovered-db-uuid', 'name' => 'My DB'],
+                ],
+                'redis' => [],
+            ], 200),
+        ]);
+
+        $service = app(CoolifyProjectService::class);
+
+        expect($service->getDatabaseUuid())->toBe('discovered-db-uuid');
+    });
+
+    it('discovers redis UUID from project environment', function () {
+        config([
+            'coolify.project_uuid' => 'test-project-uuid',
+            'coolify.environment' => 'production',
+            'coolify.redis_uuid' => null,
+        ]);
+
+        Http::fake([
+            '*/projects/test-project-uuid/production' => Http::response([
+                'applications' => [],
+                'postgresqls' => [],
+                'dragonflies' => [
+                    ['uuid' => 'discovered-redis-uuid', 'name' => 'My Cache'],
+                ],
+            ], 200),
+        ]);
+
+        $service = app(CoolifyProjectService::class);
+
+        expect($service->getRedisUuid())->toBe('discovered-redis-uuid');
+    });
+
+    it('caches project environment data', function () {
+        config([
+            'coolify.project_uuid' => 'cache-test-project-uuid',
+            'coolify.environment' => 'production',
+            'coolify.cache_ttl' => 30,
+            'coolify.application_uuid' => null,
+        ]);
+
+        Http::fake([
+            '*/projects/cache-test-project-uuid/production' => Http::response([
+                'applications' => [
+                    ['uuid' => 'cached-app-uuid', 'name' => 'Cached App'],
+                ],
+            ], 200),
+        ]);
+
+        $service = app(CoolifyProjectService::class);
+
+        // First call - should hit API
+        $service->getApplicationUuid();
+
+        // Second call - should use cache
+        $service->getApplicationUuid();
+
+        Http::assertSentCount(1);
+    });
+
+    it('clears cache when requested', function () {
+        // This test verifies that clearCache() removes the correct cache keys
+        $uniqueProjectUuid = 'clear-cache-test-uuid';
+
+        config([
+            'coolify.project_uuid' => $uniqueProjectUuid,
+            'coolify.environment' => 'production',
+            'coolify.cache_ttl' => 300,
+        ]);
+
+        // Pre-populate cache
+        $cachePrefix = 'coolify:project:';
+        Cache::put("{$cachePrefix}environment:{$uniqueProjectUuid}:production", ['cached' => true], 300);
+
+        // Verify cache exists
+        expect(Cache::has("{$cachePrefix}environment:{$uniqueProjectUuid}:production"))->toBeTrue();
+
+        // Create service and clear cache
+        $service = new \Stumason\Coolify\Services\CoolifyProjectService(
+            app(\Stumason\Coolify\Contracts\ProjectRepository::class)
+        );
+        $service->clearCache();
+
+        // Verify cache was cleared
+        expect(Cache::has("{$cachePrefix}environment:{$uniqueProjectUuid}:production"))->toBeFalse();
+    });
+
+    it('returns resource summary', function () {
+        config([
+            'coolify.project_uuid' => 'test-project-uuid',
+            'coolify.environment' => 'production',
+            'coolify.application_uuid' => 'app-uuid',
+            'coolify.database_uuid' => 'db-uuid',
+            'coolify.redis_uuid' => 'redis-uuid',
+            'coolify.server_uuid' => 'server-uuid',
+        ]);
+
+        Http::fake([
+            '*/projects/test-project-uuid/production' => Http::response([
+                'applications' => [
+                    ['uuid' => 'app-uuid', 'name' => 'Test App', 'status' => 'running'],
+                ],
+                'postgresqls' => [
+                    ['uuid' => 'db-uuid', 'name' => 'Test DB'],
+                ],
+            ], 200),
+        ]);
+
+        $service = app(CoolifyProjectService::class);
+        $summary = $service->getResourceSummary();
+
+        expect($summary)
+            ->toHaveKey('project_uuid', 'test-project-uuid')
+            ->toHaveKey('environment', 'production')
+            ->toHaveKey('application_uuid', 'app-uuid')
+            ->toHaveKey('database_uuid', 'db-uuid')
+            ->toHaveKey('redis_uuid', 'redis-uuid')
+            ->toHaveKey('server_uuid', 'server-uuid');
+    });
+});


### PR DESCRIPTION
This replaces the local database storage approach with environment variable based configuration. Coolify is now the single source of truth for all resource data.

Closes #42

Generated with [Claude Code](https://claude.ai/claude-code)