### PR TITLE
chore: clean up docs and remove dead migration code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Database storage for resource configuration (`coolify_resources` table)
-- `CoolifyResource` Eloquent model with `getDefault()` helper
-- Pre-built Docker base images for faster deployments (~12 min → ~2-3 min)
+- Multi-environment support in dashboard with environment switcher
+- Environment badge displayed prominently in dashboard header
+- Stats endpoint accepts `?environment=` query parameter
+
+### Changed
+- Dashboard fetches resources from environment endpoint instead of global endpoints
+- Application lookup now uses environment's applications array instead of git repository matching
+
+### Removed
+- Dead migration code referencing non-existent `coolify_resources` table
+
+## [3.0.0] - 2026-01-22
+
+### Added
+- Pre-built Docker base images for faster deployments (~12 min to ~2-3 min)
   - `ghcr.io/stumason/laravel-coolify-base:8.3` / `8.4` / `8.3-node` / `8.4-node`
   - GitHub Actions workflow for nightly security patch rebuilds
   - Multi-architecture support (amd64, arm64)
@@ -19,19 +31,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `COOLIFY_USE_BASE_IMAGE` - Use pre-built base images (default: true)
   - `COOLIFY_AUTO_MIGRATE` - Run migrations on startup (default: true)
   - `COOLIFY_DB_WAIT_TIMEOUT` - DB wait timeout in seconds (default: 30)
-- Documentation for Docker deployment and base images
 
 ### Changed
-- Resource UUIDs now stored in database instead of `.env` file
-- All commands read from database via `CoolifyResource::getDefault()`
-- `coolify:provision` saves to database instead of updating `.env`
 - Dockerfile generator now uses base images by default for faster builds
 - Auto-detect Node.js requirement from `package.json` for base image selection
 - Entrypoint script now waits for database connection before migrating
 
 ### Removed
-- `COOLIFY_APPLICATION_UUID`, `COOLIFY_SERVER_UUID`, `COOLIFY_PROJECT_UUID` env vars
-- `COOLIFY_DEPLOY_KEY_UUID`, `COOLIFY_DATABASE_UUID`, `COOLIFY_REDIS_UUID` env vars
+- `CoolifyResource` Eloquent model (resources now fetched directly from API)
+- Application/database/server UUID environment variables (only `COOLIFY_PROJECT_UUID` needed)
+
+## [2.9.0] - 2026-01-20
+
+### Added
+- Documentation site built with Astro Starlight
 
 ## [2.8.0] - 2026-01-15
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ COOLIFY_TOKEN=your-api-token
 COOLIFY_PROJECT_UUID=your-project-uuid  # Added automatically by provision
 ```
 
-The package automatically finds your application by matching your local git repository with applications in Coolify. No need to manually configure application UUIDs.
+The dashboard automatically fetches your application and resources from the configured project's environment. No need to manually configure application UUIDs.
 
 ```php
 // config/coolify.php

--- a/docs/src/content/docs/advanced/multi-app.md
+++ b/docs/src/content/docs/advanced/multi-app.md
@@ -1,9 +1,13 @@
 ---
-title: Multiple Applications
-description: Manage multiple apps from one Laravel install
+title: Multiple Environments
+description: Manage multiple environments from one Laravel install
 ---
 
-## Multiple Environments
+## Environment Support
+
+The dashboard supports multiple environments within a single Coolify project. Use the environment switcher in the sidebar to switch between environments like production, staging, and development.
+
+## Provisioning Environments
 
 Provision separate environments within the same project:
 
@@ -23,30 +27,7 @@ php artisan coolify:provision \
   --all
 ```
 
-Each provisioning creates a separate record in `coolify_resources`. The most recent becomes the default.
-
-## Using Specific Resources
-
-Override the default with `--uuid`:
-
-```bash
-# Deploy staging
-php artisan coolify:deploy --uuid=staging-app-uuid
-
-# Check production status
-php artisan coolify:status --uuid=prod-app-uuid
-
-# View staging logs
-php artisan coolify:logs --uuid=staging-app-uuid
-```
-
-## View All Resources
-
-```bash
-php artisan coolify:status --all
-```
-
-Shows all applications and databases across your Coolify instance.
+Each environment gets its own application, database, and cache resources.
 
 ## Coolify Project Structure
 
@@ -68,9 +49,32 @@ graph TB
 
 ## Dashboard
 
-The dashboard shows the default resource. To manage multiple environments:
+The dashboard includes an environment switcher in the sidebar. Click on the current environment name to see all available environments and switch between them.
 
-1. Use Coolify's web UI for full environment management
-2. Or use `--uuid` flags with artisan commands
+Each environment view shows:
+- Application status and deployment history
+- Database and cache resources for that environment
+- Environment-specific logs and configuration
 
-The dashboard includes a direct link to the Coolify console for each resource.
+## CLI Commands with UUID
+
+For CLI operations targeting specific resources, use the `--uuid` flag:
+
+```bash
+# Deploy specific application
+php artisan coolify:deploy --uuid=staging-app-uuid
+
+# Check specific application status
+php artisan coolify:status --uuid=prod-app-uuid
+
+# View specific application logs
+php artisan coolify:logs --uuid=staging-app-uuid
+```
+
+## View All Resources
+
+```bash
+php artisan coolify:status --all
+```
+
+Shows all applications and databases across your Coolify instance.

--- a/docs/src/content/docs/commands/provision.md
+++ b/docs/src/content/docs/commands/provision.md
@@ -59,7 +59,7 @@ After provisioning, `COOLIFY_PROJECT_UUID` is automatically added to your local 
 COOLIFY_PROJECT_UUID=abc123-def456-...
 ```
 
-All other commands (`coolify:deploy`, `coolify:status`, etc.) automatically find your application by matching your local git repository with applications in Coolify. No manual UUID configuration is required.
+The dashboard fetches your application and resources from the selected environment. Use the environment switcher to view different environments within your project.
 
 ## Generated Files
 

--- a/docs/src/content/docs/getting-started/configuration.md
+++ b/docs/src/content/docs/getting-started/configuration.md
@@ -39,14 +39,13 @@ COOLIFY_PHP_MEMORY_LIMIT=256M
 
 ## How Application Lookup Works
 
-The package automatically finds your application by matching your local git repository URL with applications in Coolify. When you run commands like `coolify:deploy` or `coolify:status`:
+The dashboard fetches your application directly from the Coolify API using your project and environment:
 
 1. It reads `COOLIFY_PROJECT_UUID` from your `.env`
-2. Fetches all applications from Coolify
-3. Matches your local `git remote get-url origin` with application git repositories
-4. Uses the matching application for all operations
+2. Fetches resources from the selected environment (defaults to "production")
+3. Uses the first application in that environment
 
-This means no manual UUID configuration is needed after provisioning.
+The dashboard includes an environment switcher to view different environments within your project. No manual UUID configuration is needed after provisioning.
 
 ## Dashboard Authentication
 

--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ php artisan coolify:install
 
 This will:
 - Publish `config/coolify.php`
-- Publish and run migrations (creates `coolify_resources` table)
+- Publish dashboard assets
 - Generate Dockerfile and docker configs
 - Configure TrustProxies middleware
 

--- a/docs/src/content/docs/reference/config.md
+++ b/docs/src/content/docs/reference/config.md
@@ -74,11 +74,10 @@ return [
 
 Only `COOLIFY_PROJECT_UUID` is stored in your `.env` file. All other resource UUIDs are fetched from the Coolify API automatically.
 
-When you run commands like `coolify:deploy` or `coolify:status`:
+The dashboard fetches your application and resources directly from the selected environment:
 
 1. The package reads `COOLIFY_PROJECT_UUID` from your config
-2. Fetches all applications from Coolify
-3. Matches your local `git remote get-url origin` with application git repositories
-4. Uses the matching application for operations
+2. Fetches resources from the selected environment (defaults to "production")
+3. Uses the first application in that environment for operations
 
-This means no manual UUID configuration is needed after provisioning.
+The dashboard includes an environment switcher to view different environments within your project. No manual UUID configuration is needed after provisioning.

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Stumason\Coolify\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Stumason\Coolify\Docker\DockerGenerator;
@@ -42,7 +41,7 @@ class InstallCommand extends Command
         info('Installing Laravel Coolify...');
         $this->newLine();
 
-        // Publish config, service provider, migrations, and assets
+        // Publish config, service provider, and assets
         collect([
             'Service Provider' => fn () => $this->callSilent('vendor:publish', [
                 '--tag' => 'coolify-provider',
@@ -50,10 +49,6 @@ class InstallCommand extends Command
             ]) == 0,
             'Configuration' => fn () => $this->callSilent('vendor:publish', [
                 '--tag' => 'coolify-config',
-                '--force' => $this->option('force'),
-            ]) == 0,
-            'Migrations' => fn () => $this->callSilent('vendor:publish', [
-                '--tag' => 'coolify-migrations',
                 '--force' => $this->option('force'),
             ]) == 0,
             'Assets' => fn () => $this->callSilent('vendor:publish', [
@@ -64,16 +59,6 @@ class InstallCommand extends Command
 
         $this->registerCoolifyServiceProvider();
         $this->configureTrustedProxies();
-
-        // Run migrations (gracefully handles if already migrated)
-        $this->components->task('Run Migrations', function () {
-            // Check if table exists to avoid re-running
-            if (! Schema::hasTable('coolify_resources')) {
-                return $this->callSilent('migrate') == 0;
-            }
-
-            return true;
-        });
 
         // Generate Docker deployment config
         if (! $this->option('no-docker')) {

--- a/src/CoolifyServiceProvider.php
+++ b/src/CoolifyServiceProvider.php
@@ -156,10 +156,6 @@ class CoolifyServiceProvider extends ServiceProvider
             ], 'coolify-views');
 
             $this->publishes([
-                __DIR__.'/../database/migrations' => database_path('migrations'),
-            ], 'coolify-migrations');
-
-            $this->publishes([
                 __DIR__.'/../dist' => public_path('vendor/coolify'),
             ], 'coolify-assets');
         }


### PR DESCRIPTION
## Summary
- Remove all references to non-existent `coolify_resources` table
- Remove dead migration code from InstallCommand and ServiceProvider
- Update docs to reflect environment-based resource fetching (not git repo matching)
- Rewrite CHANGELOG with accurate v3.0.0 and [Unreleased] sections
- Document environment switcher functionality in multi-app.md

## Test plan
- [x] `composer test` passes (230 tests)
- [x] `composer lint` passes