### PR TITLE
feat: add PHP 8.5 base images, bump Node to 24 (closes #77)

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -50,11 +50,17 @@ jobs:
           - dockerfile: 'Dockerfile.8.4'
             tag: '8.4'
             node: false
+          - dockerfile: 'Dockerfile.8.5'
+            tag: '8.5'
+            node: false
           - dockerfile: 'Dockerfile.8.3-node'
             tag: '8.3-node'
             node: true
           - dockerfile: 'Dockerfile.8.4-node'
             tag: '8.4-node'
+            node: true
+          - dockerfile: 'Dockerfile.8.5-node'
+            tag: '8.5-node'
             node: true
         arch:
           - runner: ubuntu-latest
@@ -112,9 +118,13 @@ jobs:
             node: false
           - tag: '8.4'
             node: false
+          - tag: '8.5'
+            node: false
           - tag: '8.3-node'
             node: true
           - tag: '8.4-node'
+            node: true
+          - tag: '8.5-node'
             node: true
 
     steps:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -63,6 +63,26 @@ jobs:
           timeoutSeconds: 600
           intervalSeconds: 30
 
+      - name: Wait for PHP 8.5 / Laravel 12 tests
+        uses: fountainhead/action-wait-for-check@v1.2.0
+        id: wait-for-php85-l12
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: "PHP 8.5 / Laravel 12.*"
+          ref: ${{ github.event.pull_request.head.sha }}
+          timeoutSeconds: 600
+          intervalSeconds: 30
+
+      - name: Wait for PHP 8.5 / Laravel 13 tests
+        uses: fountainhead/action-wait-for-check@v1.2.0
+        id: wait-for-php85-l13
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: "PHP 8.5 / Laravel 13.*"
+          ref: ${{ github.event.pull_request.head.sha }}
+          timeoutSeconds: 600
+          intervalSeconds: 30
+
       - name: Wait for Pint
         uses: fountainhead/action-wait-for-check@v1.2.0
         id: wait-for-pint
@@ -89,6 +109,8 @@ jobs:
           steps.wait-for-php83-l13.outputs.conclusion == 'success' &&
           steps.wait-for-php84-l12.outputs.conclusion == 'success' &&
           steps.wait-for-php84-l13.outputs.conclusion == 'success' &&
+          steps.wait-for-php85-l12.outputs.conclusion == 'success' &&
+          steps.wait-for-php85-l13.outputs.conclusion == 'success' &&
           steps.wait-for-pint.outputs.conclusion == 'success' &&
           steps.wait-for-phpstan.outputs.conclusion == 'success' &&
           (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch')
@@ -103,6 +125,8 @@ jobs:
           steps.wait-for-php83-l13.outputs.conclusion == 'success' &&
           steps.wait-for-php84-l12.outputs.conclusion == 'success' &&
           steps.wait-for-php84-l13.outputs.conclusion == 'success' &&
+          steps.wait-for-php85-l12.outputs.conclusion == 'success' &&
+          steps.wait-for-php85-l13.outputs.conclusion == 'success' &&
           steps.wait-for-pint.outputs.conclusion == 'success' &&
           steps.wait-for-phpstan.outputs.conclusion == 'success' &&
           steps.metadata.outputs.dependency-type == 'direct:production' &&

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4']
+        php: ['8.3', '8.4', '8.5']
         laravel: ['12.*', '13.*']
 
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}

--- a/config/coolify.php
+++ b/config/coolify.php
@@ -190,7 +190,7 @@ return [
     */
 
     'docker' => [
-        // PHP version for the production image (e.g., '8.3', '8.4')
+        // PHP version for the production image (e.g., '8.3', '8.4', '8.5')
         'php_version' => env('COOLIFY_PHP_VERSION', '8.4'),
 
         // Health check endpoint path

--- a/docker/base/Dockerfile.8.3-node
+++ b/docker/base/Dockerfile.8.3-node
@@ -1,5 +1,5 @@
 # =============================================================================
-# Laravel Coolify Base Image - PHP 8.3 + Node.js 20
+# Laravel Coolify Base Image - PHP 8.3 + Node.js 24
 # =============================================================================
 # Pre-built image with all system dependencies, PHP extensions, and Node.js.
 # Using this image reduces deployment time from ~12 minutes to ~2-3 minutes.
@@ -11,7 +11,7 @@ FROM php:8.3-fpm-bookworm
 
 LABEL maintainer="Stu Mason <me@stumason.dev>" \
       org.opencontainers.image.title="Laravel Coolify Base (Node)" \
-      org.opencontainers.image.description="Pre-built PHP 8.3 + Node.js 20 base image for Laravel applications deployed via Coolify" \
+      org.opencontainers.image.description="Pre-built PHP 8.3 + Node.js 24 base image for Laravel applications deployed via Coolify" \
       org.opencontainers.image.source="https://github.com/StuMason/laravel-coolify" \
       org.opencontainers.image.version="8.3-node"
 
@@ -46,12 +46,12 @@ RUN apt-get update \
     && apt-get clean
 
 # =============================================================================
-# Node.js 20 LTS
+# Node.js 24 LTS
 # =============================================================================
-# Installed via NodeSource for the latest LTS version.
+# Installed via NodeSource for the current Active LTS version.
 # Includes npm for package management.
 # =============================================================================
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean \

--- a/docker/base/Dockerfile.8.5
+++ b/docker/base/Dockerfile.8.5
@@ -1,19 +1,19 @@
 # =============================================================================
-# Laravel Coolify Base Image - PHP 8.4 + Node.js 24
+# Laravel Coolify Base Image - PHP 8.5
 # =============================================================================
-# Pre-built image with all system dependencies, PHP extensions, and Node.js.
+# Pre-built image with all system dependencies and PHP extensions compiled.
 # Using this image reduces deployment time from ~12 minutes to ~2-3 minutes.
 #
-# Published to: ghcr.io/stumason/laravel-coolify-base:8.4-node
+# Published to: ghcr.io/stumason/laravel-coolify-base:8.5
 # =============================================================================
 
-FROM php:8.4-fpm-bookworm
+FROM php:8.5-fpm-bookworm
 
 LABEL maintainer="Stu Mason <me@stumason.dev>" \
-      org.opencontainers.image.title="Laravel Coolify Base (Node)" \
-      org.opencontainers.image.description="Pre-built PHP 8.4 + Node.js 24 base image for Laravel applications deployed via Coolify" \
+      org.opencontainers.image.title="Laravel Coolify Base" \
+      org.opencontainers.image.description="Pre-built PHP 8.5 base image for Laravel applications deployed via Coolify" \
       org.opencontainers.image.source="https://github.com/StuMason/laravel-coolify" \
-      org.opencontainers.image.version="8.4-node"
+      org.opencontainers.image.version="8.5"
 
 # =============================================================================
 # System Dependencies
@@ -32,7 +32,6 @@ RUN apt-get update \
         unzip \
         git \
         ca-certificates \
-        gnupg \
         # PHP extension dependencies
         libpq-dev \
         libzip-dev \
@@ -44,18 +43,6 @@ RUN apt-get update \
         libicu-dev \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
-
-# =============================================================================
-# Node.js 24 LTS
-# =============================================================================
-# Installed via NodeSource for the current Active LTS version.
-# Includes npm for package management.
-# =============================================================================
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean \
-    && npm install -g npm@latest
 
 # =============================================================================
 # PHP Extensions
@@ -102,12 +89,10 @@ WORKDIR /var/www/html
 # =============================================================================
 # Verification
 # =============================================================================
-# Verify all extensions and Node.js are properly installed.
+# Verify all extensions are properly installed.
 # This runs during image build to catch issues early.
 # =============================================================================
 RUN php -m | grep -E "pdo|redis|gd|intl|opcache" \
     && php -v \
     && nginx -v \
-    && node -v \
-    && npm -v \
-    && echo "Base image (with Node.js) ready!"
+    && echo "Base image ready!"

--- a/docker/base/Dockerfile.8.5-node
+++ b/docker/base/Dockerfile.8.5-node
@@ -1,19 +1,19 @@
 # =============================================================================
-# Laravel Coolify Base Image - PHP 8.4 + Node.js 24
+# Laravel Coolify Base Image - PHP 8.5 + Node.js 24
 # =============================================================================
 # Pre-built image with all system dependencies, PHP extensions, and Node.js.
 # Using this image reduces deployment time from ~12 minutes to ~2-3 minutes.
 #
-# Published to: ghcr.io/stumason/laravel-coolify-base:8.4-node
+# Published to: ghcr.io/stumason/laravel-coolify-base:8.5-node
 # =============================================================================
 
-FROM php:8.4-fpm-bookworm
+FROM php:8.5-fpm-bookworm
 
 LABEL maintainer="Stu Mason <me@stumason.dev>" \
       org.opencontainers.image.title="Laravel Coolify Base (Node)" \
-      org.opencontainers.image.description="Pre-built PHP 8.4 + Node.js 24 base image for Laravel applications deployed via Coolify" \
+      org.opencontainers.image.description="Pre-built PHP 8.5 + Node.js 24 base image for Laravel applications deployed via Coolify" \
       org.opencontainers.image.source="https://github.com/StuMason/laravel-coolify" \
-      org.opencontainers.image.version="8.4-node"
+      org.opencontainers.image.version="8.5-node"
 
 # =============================================================================
 # System Dependencies

--- a/docker/base/README.md
+++ b/docker/base/README.md
@@ -8,8 +8,10 @@ Pre-built Docker images with all system dependencies and PHP extensions compiled
 |-------|-----|---------|----------|
 | `ghcr.io/stumason/laravel-coolify-base:8.3` | 8.3 | - | API-only or Blade apps |
 | `ghcr.io/stumason/laravel-coolify-base:8.4` | 8.4 | - | API-only or Blade apps |
-| `ghcr.io/stumason/laravel-coolify-base:8.3-node` | 8.3 | 20 LTS | Full-stack with Vite/Inertia |
-| `ghcr.io/stumason/laravel-coolify-base:8.4-node` | 8.4 | 20 LTS | Full-stack with Vite/Inertia |
+| `ghcr.io/stumason/laravel-coolify-base:8.5` | 8.5 | - | API-only or Blade apps |
+| `ghcr.io/stumason/laravel-coolify-base:8.3-node` | 8.3 | 24 LTS | Full-stack with Vite/Inertia |
+| `ghcr.io/stumason/laravel-coolify-base:8.4-node` | 8.4 | 24 LTS | Full-stack with Vite/Inertia |
+| `ghcr.io/stumason/laravel-coolify-base:8.5-node` | 8.5 | 24 LTS | Full-stack with Vite/Inertia |
 
 ## What's Included
 
@@ -26,7 +28,7 @@ Pre-built Docker images with all system dependencies and PHP extensions compiled
 - **Cache:** redis (via PECL)
 
 ### Node.js (for `-node` variants)
-- Node.js 20 LTS
+- Node.js 24 LTS
 - npm (latest)
 
 ## What's NOT Included


### PR DESCRIPTION
## Summary

Closes #77.

- Add `Dockerfile.8.5` and `Dockerfile.8.5-node`, mirroring the 8.4 variants
- Bump Node.js from 20 LTS to 24 LTS across all `-node` images (Node 20 hit EOL in April 2026; 24 is the current Active LTS)
- Add `8.5` / `8.5-node` to the `build-base-images` build + manifest matrix
- Add PHP 8.5 to the `Tests` CI matrix (6 combinations now)
- Update `docker/base/README.md` and `config/coolify.php` docs

After merge, the nightly base-image workflow will publish:

| Tag | PHP | Node |
|---|---|---|
| `:8.3` | 8.3 | - |
| `:8.4` | 8.4 | - |
| `:8.5` | 8.5 | - |
| `:8.3-node` | 8.3 | 24 |
| `:8.4-node` | 8.4 | 24 |
| `:8.5-node` | 8.5 | 24 |

## Test plan

- [x] `composer test` passes locally on PHP 8.4 (270/270)
- [x] `composer test` passes locally on PHP 8.5 (270/270)
- [x] `vendor/bin/pint --test` clean
- [ ] Build Base Images workflow succeeds for the new 8.5 / 8.5-node tags after merge
- [ ] CI test matrix runs PHP 8.5 cleanly

## Note on Node bump

Existing consumers pulling `:8.3-node` or `:8.4-node` will silently get Node 24 instead of Node 20 on next deploy. Tag is `-node` (unversioned), so this matches the documented "current LTS" intent. Worth a release-note callout.