### PR TITLE
ci: fix nightly PHP 8.5 base image build + spurious automerge runs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -3,9 +3,6 @@ name: Dependabot Auto-merge
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  workflow_run:
-    workflows: ["Tests", "Lint"]
-    types: [completed]
 
 permissions:
   contents: write

--- a/docker/base/Dockerfile.8.5
+++ b/docker/base/Dockerfile.8.5
@@ -51,7 +51,7 @@ RUN apt-get update \
 # Extensions are pre-compiled to avoid build time during deployments.
 # =============================================================================
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install -j$(nproc) \
+    && docker-php-ext-install -j1 \
         pdo \
         pdo_mysql \
         pdo_pgsql \

--- a/docker/base/Dockerfile.8.5
+++ b/docker/base/Dockerfile.8.5
@@ -51,6 +51,9 @@ RUN apt-get update \
 # Extensions are pre-compiled to avoid build time during deployments.
 # =============================================================================
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
+    # -j1 (not -j$(nproc)): PHP 8.5's install-modules make target copies modules/*
+    # before parallel compile finishes; -j>1 races and fails the build. Revisit
+    # once upstream fixes the Makefile ordering. See PR #97 for context.
     && docker-php-ext-install -j1 \
         pdo \
         pdo_mysql \

--- a/docker/base/Dockerfile.8.5-node
+++ b/docker/base/Dockerfile.8.5-node
@@ -64,7 +64,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 # Extensions are pre-compiled to avoid build time during deployments.
 # =============================================================================
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install -j$(nproc) \
+    && docker-php-ext-install -j1 \
         pdo \
         pdo_mysql \
         pdo_pgsql \

--- a/docker/base/Dockerfile.8.5-node
+++ b/docker/base/Dockerfile.8.5-node
@@ -64,6 +64,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 # Extensions are pre-compiled to avoid build time during deployments.
 # =============================================================================
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
+    # -j1 (not -j$(nproc)): PHP 8.5's install-modules make target copies modules/*
+    # before parallel compile finishes; -j>1 races and fails the build. Revisit
+    # once upstream fixes the Makefile ordering. See PR #97 for context.
     && docker-php-ext-install -j1 \
         pdo \
         pdo_mysql \


### PR DESCRIPTION
## Summary

Two unrelated CI bugs, both visible since PHP 8.5 was added in #92 on 2026-04-28. Bundled together because they're both small workflow / Dockerfile fixes.

### 1. Nightly PHP 8.5 base image build broken (13 days running)

**Symptom:** `build-base-images.yml` schedule run fails every night since 2026-04-28. All four PHP 8.5 jobs fail at the "Build and push" step on both amd64 and arm64. PHP 8.3 and 8.4 are unaffected.

**Root cause:** `docker-php-ext-install -j$(nproc)` hits a race condition in PHP 8.5's revised build system — the `install-modules` make target runs `cp modules/*` before the parallel compile finishes:

```
#9 77.80 cp: cannot stat 'modules/*': No such file or directory
#9 77.80 make: *** [Makefile:89: install-modules] Error 1
#9 77.80 make: *** Waiting for unfinished jobs....
ERROR: failed to solve: process "docker-php-ext-install -j$(nproc) ..." did not complete successfully: exit code: 2
```

**Fix:** Drop to `-j1` on `Dockerfile.8.5` and `Dockerfile.8.5-node`. Slower nightly compile, but a nightly build trading speed for reliability is the right call.

### 2. Dependabot automerge workflow spuriously failing

**Symptom:** 3 automerge workflow runs failed today alone with the misleading error:

```
##[warning]Event payload missing `pull_request` key.
##[error]PR is not from Dependabot, nothing to do.
```

**Root cause:** The workflow had `workflow_run` configured to fire whenever Tests or Lint completed — including on `main` after a PR merges. In that context `github.event.pull_request` is null, but `github.actor` is still `dependabot[bot]` (because the merged PR was from dependabot), so the job runs and `dependabot/fetch-metadata@v3` bails with the error above.

**Fix:** Drop the `workflow_run` trigger entirely. It was a belt-and-suspenders backup, but the existing `fountainhead/action-wait-for-check` polling inside the job already handles the "wait for Tests/Lint to complete" case it was trying to backstop. If a real timeout case ever shows up, we can add it back with proper PR-context extraction (`github.event.workflow_run.pull_requests`).

### Closes

- Closes #94 (auto-filed nightly build failure)

## Test plan

- [ ] CI on this PR runs clean (Tests / Lint / Pint / PHPStan)
- [ ] After merge, manually trigger `build-base-images.yml` and confirm all 8.5 variants build successfully
- [ ] Watch the next nightly run lands green
- [ ] Confirm no spurious automerge failures on `main` after the next dependabot merge