### PR TITLE
fix(docker): split opcache into its own RUN on PHP 8.5

### DIFF
--- a/docker/base/Dockerfile.8.5
+++ b/docker/base/Dockerfile.8.5
@@ -70,7 +70,7 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
 # inter-extension teardown when opcache shares an invocation with other exts,
 # so the helpers are gone before opcache itself starts compiling — `modules/`
 # stays empty and `install-modules` fails with `cp: cannot stat 'modules/*'`.
-# Splitting opcache into its own RUN avoids the shared teardown entirely. See #98.
+# Splitting opcache into its own RUN avoids the shared teardown entirely. See #100.
 RUN docker-php-ext-install -j"$(nproc)" opcache
 
 # =============================================================================

--- a/docker/base/Dockerfile.8.5
+++ b/docker/base/Dockerfile.8.5
@@ -51,10 +51,7 @@ RUN apt-get update \
 # Extensions are pre-compiled to avoid build time during deployments.
 # =============================================================================
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
-    # -j1 (not -j$(nproc)): PHP 8.5's install-modules make target copies modules/*
-    # before parallel compile finishes; -j>1 races and fails the build. Revisit
-    # once upstream fixes the Makefile ordering. See PR #97 for context.
-    && docker-php-ext-install -j1 \
+    && docker-php-ext-install -j"$(nproc)" \
         pdo \
         pdo_mysql \
         pdo_pgsql \
@@ -65,8 +62,16 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
         xml \
         bcmath \
         intl \
-        opcache \
         pcntl
+
+# opcache must be installed on its own. In PHP 8.5 the JIT IR added build-time
+# helpers (`ext/opcache/jit/ir/gen_ir_fold_hash`, `minilua`) that are produced
+# during opcache's compile phase. docker-php-ext-install cleans those up in the
+# inter-extension teardown when opcache shares an invocation with other exts,
+# so the helpers are gone before opcache itself starts compiling — `modules/`
+# stays empty and `install-modules` fails with `cp: cannot stat 'modules/*'`.
+# Splitting opcache into its own RUN avoids the shared teardown entirely. See #98.
+RUN docker-php-ext-install -j"$(nproc)" opcache
 
 # =============================================================================
 # PECL Extensions

--- a/docker/base/Dockerfile.8.5-node
+++ b/docker/base/Dockerfile.8.5-node
@@ -83,7 +83,7 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
 # inter-extension teardown when opcache shares an invocation with other exts,
 # so the helpers are gone before opcache itself starts compiling — `modules/`
 # stays empty and `install-modules` fails with `cp: cannot stat 'modules/*'`.
-# Splitting opcache into its own RUN avoids the shared teardown entirely. See #98.
+# Splitting opcache into its own RUN avoids the shared teardown entirely. See #100.
 RUN docker-php-ext-install -j"$(nproc)" opcache
 
 # =============================================================================

--- a/docker/base/Dockerfile.8.5-node
+++ b/docker/base/Dockerfile.8.5-node
@@ -64,10 +64,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 # Extensions are pre-compiled to avoid build time during deployments.
 # =============================================================================
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
-    # -j1 (not -j$(nproc)): PHP 8.5's install-modules make target copies modules/*
-    # before parallel compile finishes; -j>1 races and fails the build. Revisit
-    # once upstream fixes the Makefile ordering. See PR #97 for context.
-    && docker-php-ext-install -j1 \
+    && docker-php-ext-install -j"$(nproc)" \
         pdo \
         pdo_mysql \
         pdo_pgsql \
@@ -78,8 +75,16 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
         xml \
         bcmath \
         intl \
-        opcache \
         pcntl
+
+# opcache must be installed on its own. In PHP 8.5 the JIT IR added build-time
+# helpers (`ext/opcache/jit/ir/gen_ir_fold_hash`, `minilua`) that are produced
+# during opcache's compile phase. docker-php-ext-install cleans those up in the
+# inter-extension teardown when opcache shares an invocation with other exts,
+# so the helpers are gone before opcache itself starts compiling — `modules/`
+# stays empty and `install-modules` fails with `cp: cannot stat 'modules/*'`.
+# Splitting opcache into its own RUN avoids the shared teardown entirely. See #98.
+RUN docker-php-ext-install -j"$(nproc)" opcache
 
 # =============================================================================
 # PECL Extensions


### PR DESCRIPTION
## Summary

#97 attempted to fix the nightly base-image build failure with `-j$(nproc)` → `-j1`. Manual verification afterwards showed **the build still fails** with the same error. Different root cause.

## What's actually wrong

PHP 8.5 added a JIT IR to opcache. The opcache extension now needs build-time helper tools — `ext/opcache/jit/ir/gen_ir_fold_hash` and `ext/opcache/jit/ir/minilua` — which are produced during opcache's own compile phase.

`docker-php-ext-install` runs a teardown between extensions in the same invocation. From the build log on run `25675646255`:

```
113.7 intl install — Build complete.
113.8 find . -name *.gcno ...                  ← teardown
113.9 find . -name *.la ...                    ← teardown
113.9 find . -name .libs -a -type d ...        ← teardown
113.9 rm -f libphp.la modules/* libs/*         ← teardown
113.9 rm -f ext/opcache/jit/ir/gen_ir_fold_hash   ← WIPES opcache JIT helpers
113.9 rm -f ext/opcache/jit/ir/minilua             ← WIPES opcache JIT helpers
115.5 configure: creating Makefile             ← opcache configure starts
116.0 Installing shared extensions: ...        ← but no compile output between!
116.1 cp: cannot stat 'modules/*': No such file
```

The teardown deletes the JIT helpers *before* opcache itself starts compiling. opcache then can't produce a `.so` because its build needs the helpers it just lost. `modules/` stays empty, `install-modules` fails.

#97's `-j1` change didn't help because parallelism wasn't the issue — teardown ordering was.

## Fix

Install opcache in its own `RUN`. Shared-invocation teardown never touches its build artifacts. Also restored `-j$(nproc)` on the bulk install — without opcache in the mix, parallel build works fine on 8.5.

Net: nightly build time stays roughly where it was on 8.4. opcache's compile is fast even with a fresh `make` invocation; parallelism is restored for everything else.

## Test plan

- [x] CI lane builds clean on this PR
- [ ] Manual `build-base-images.yml` dispatch after merge — confirm all 8.5 jobs go green
- [ ] Watch the next nightly run lands green