### PR TITLE
fix(docker): use install-php-extensions for PHP 8.5 base images

### DIFF
--- a/docker/base/Dockerfile.8.5
+++ b/docker/base/Dockerfile.8.5
@@ -50,8 +50,17 @@ RUN apt-get update \
 # Includes both MySQL and PostgreSQL drivers for maximum compatibility.
 # Extensions are pre-compiled to avoid build time during deployments.
 # =============================================================================
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install -j"$(nproc)" \
+# Use mlocati/install-php-extensions instead of docker-php-ext-install: the
+# stock script fails on PHP 8.5's opcache (make produces no compile output and
+# `install-modules` fails on an empty `modules/`). install-php-extensions is
+# the community-maintained alternative that handles per-version quirks. See
+# #97 / #100 for the two failed docker-php-ext-install attempts before this
+# switch; once docker-php-ext-install ships a PHP 8.5 fix upstream we can
+# revisit. 8.3 and 8.4 Dockerfiles still use docker-php-ext-install — it
+# works fine on those versions.
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
+RUN install-php-extensions \
         pdo \
         pdo_mysql \
         pdo_pgsql \
@@ -62,16 +71,8 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
         xml \
         bcmath \
         intl \
+        opcache \
         pcntl
-
-# opcache must be installed on its own. In PHP 8.5 the JIT IR added build-time
-# helpers (`ext/opcache/jit/ir/gen_ir_fold_hash`, `minilua`) that are produced
-# during opcache's compile phase. docker-php-ext-install cleans those up in the
-# inter-extension teardown when opcache shares an invocation with other exts,
-# so the helpers are gone before opcache itself starts compiling — `modules/`
-# stays empty and `install-modules` fails with `cp: cannot stat 'modules/*'`.
-# Splitting opcache into its own RUN avoids the shared teardown entirely. See #100.
-RUN docker-php-ext-install -j"$(nproc)" opcache
 
 # =============================================================================
 # PECL Extensions

--- a/docker/base/Dockerfile.8.5-node
+++ b/docker/base/Dockerfile.8.5-node
@@ -63,8 +63,17 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 # Includes both MySQL and PostgreSQL drivers for maximum compatibility.
 # Extensions are pre-compiled to avoid build time during deployments.
 # =============================================================================
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install -j"$(nproc)" \
+# Use mlocati/install-php-extensions instead of docker-php-ext-install: the
+# stock script fails on PHP 8.5's opcache (make produces no compile output and
+# `install-modules` fails on an empty `modules/`). install-php-extensions is
+# the community-maintained alternative that handles per-version quirks. See
+# #97 / #100 for the two failed docker-php-ext-install attempts before this
+# switch; once docker-php-ext-install ships a PHP 8.5 fix upstream we can
+# revisit. 8.3 and 8.4 Dockerfiles still use docker-php-ext-install — it
+# works fine on those versions.
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
+RUN install-php-extensions \
         pdo \
         pdo_mysql \
         pdo_pgsql \
@@ -75,16 +84,8 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
         xml \
         bcmath \
         intl \
+        opcache \
         pcntl
-
-# opcache must be installed on its own. In PHP 8.5 the JIT IR added build-time
-# helpers (`ext/opcache/jit/ir/gen_ir_fold_hash`, `minilua`) that are produced
-# during opcache's compile phase. docker-php-ext-install cleans those up in the
-# inter-extension teardown when opcache shares an invocation with other exts,
-# so the helpers are gone before opcache itself starts compiling — `modules/`
-# stays empty and `install-modules` fails with `cp: cannot stat 'modules/*'`.
-# Splitting opcache into its own RUN avoids the shared teardown entirely. See #100.
-RUN docker-php-ext-install -j"$(nproc)" opcache
 
 # =============================================================================
 # PECL Extensions


### PR DESCRIPTION
## Summary

Third (and hopefully final) attempt at fixing the nightly base-image build. **Read history before approving** — the previous two attempts (#97, #100) chased wrong hypotheses.

## What we learned from #97 / #100

- **#97 (`-j$(nproc)` → `-j1`)** — assumed parallelism race. Verified post-merge: still failed identically.
- **#100 (opcache into its own RUN)** — assumed inter-extension teardown was wiping opcache's JIT IR helpers. Verified post-merge: still failed identically. The standalone-opcache log was the smoking gun — opcache's `make all` ran in 0ms with no compile output yet emitted "Build complete.":

```
2.169 Configuring for: PHP 8.5
... configure runs to completion ...
4.410 Build complete.       ← NO COMPILE OUTPUT BEFORE THIS
4.481 cp: cannot stat 'modules/*'
```

This is a `docker-php-ext-install`-vs-PHP-8.5 incompatibility specific to opcache. I can't diagnose further without local repro.

## This change

Switches the PHP 8.5 Dockerfiles (`Dockerfile.8.5`, `Dockerfile.8.5-node`) to use [`mlocati/install-php-extensions`](https://github.com/mlocati/docker-php-extension-installer) — the de facto community-maintained alternative to `docker-php-ext-install`. Same set of extensions installed; same end state.

**Untouched:** `Dockerfile.8.3` and `Dockerfile.8.4` still use `docker-php-ext-install` — they work fine on those versions, no need to take on a new dependency there.

## Trade-offs

- **Adds a third-party script as a build dependency.** The script is from `mlocati/docker-php-extension-installer`, widely used in production, MIT licensed. Binary pinned to `latest` — open to switching to a tagged release (e.g. `v2.x`) if you'd prefer a more conservative pin.
- **Slightly different extension setup output**, but same installed extensions and same runtime behaviour.
- If `docker-php-ext-install` ships a PHP 8.5 fix upstream, we can revisit and unify back.

## Test plan

- [x] PR CI lane passes (Tests / Lint / Pint / PHPStan)
- [ ] Manual `build-base-images.yml` dispatch after merge — confirm all 8.5 jobs go green
- [ ] Watch next nightly run lands green
- [ ] If anything else regresses (it shouldn't — same extensions), happy to address in a follow-up

## Honest note

Two failed PRs in a row on the same issue is not a good look. I should've reached for `install-php-extensions` sooner instead of pattern-matching on parallelism / cleanup theories. Apologies for the noise.