### PR TITLE
ci: base images fortnightly + min-mode cache (cut ~2,500 Actions min/month)

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -8,7 +8,7 @@
 #
 # Triggers:
 # - Push to docker/base/* (when base Dockerfiles change)
-# - Nightly at 2am UTC (security patches)
+# - Fortnightly at 2am UTC, 1st & 15th (security patches)
 # - Manual workflow dispatch
 # =============================================================================
 
@@ -21,8 +21,11 @@ on:
       - 'docker/base/**'
       - '.github/workflows/build-base-images.yml'
   schedule:
-    # Nightly at 2am UTC for security patches
-    - cron: '0 2 * * *'
+    # Fortnightly at 2am UTC (1st & 15th) for security patches. Nightly rebuilds
+    # of 12 multi-arch base images were burning ~3,000 Actions minutes/month for
+    # patches that a twice-monthly cadence catches just as well. Real Dockerfile
+    # changes still rebuild immediately via the push trigger above.
+    - cron: '0 2 1,15 * *'
   workflow_dispatch:
     inputs:
       force_rebuild:
@@ -98,7 +101,11 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.variant.tag }}-${{ matrix.arch.suffix }}
           cache-from: type=gha,scope=${{ matrix.variant.tag }}-${{ matrix.arch.suffix }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.variant.tag }}-${{ matrix.arch.suffix }}
+          # mode=min: these are single-stage images, so there are no intermediate
+          # build stages for mode=max to cache — it only bloated the per-repo GHA
+          # cache (10 GB cap, LRU-evicted). Twelve max-mode scopes blew the cap and
+          # thrashed, so nightly runs kept missing cache and rebuilding cold.
+          cache-to: type=gha,mode=min,scope=${{ matrix.variant.tag }}-${{ matrix.arch.suffix }}
 
   # ===========================================================================
   # Create multi-arch manifests combining amd64 and arm64 images


### PR DESCRIPTION
## Why

The nightly **Build Base Images** workflow is the single biggest GitHub Actions consumer across all my repos — **~3,000 Linux minutes/month**, roughly the entire monthly allotment. It rebuilds **12 multi-arch images** (6 PHP variants × 2 arches) *every night* for security patches.

It was set up deliberately in #32 (pre-built base images to speed deploys), but nightly is far more aggressive than base-image patching needs.

## Changes

1. **Cadence: nightly → fortnightly** (`0 2 * * *` → `0 2 1,15 * *`, 2am on the 1st & 15th). Twice-monthly catches base-image security patches just as well, and any real Dockerfile change still rebuilds immediately via the existing `push: docker/base/**` trigger.

2. **Cache: `mode=max` → `mode=min`.** All six base Dockerfiles are **single-stage** (one `FROM`), so there are no intermediate build stages for `mode=max` to cache — it only inflated the per-repo GHA cache. The GHA cache is capped at **10 GB/repo** with LRU eviction; twelve `mode=max` scopes of full PHP+ext(+Node) images blew past the cap, so caches were evicted and nightly runs kept rebuilding cold (plus extra Actions *storage* billing). `mode=min` keeps each scope small enough to survive between runs.

## Expected saving

~**2,500 Actions minutes/month**. Real Dockerfile changes and manual `workflow_dispatch` are unaffected.