### PR TITLE
docs: cross-link coolify-mcp in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 Like Laravel Horizon for queues, but for your entire infrastructure.
 
+> 💡 **Using an AI assistant?** Check out [**coolify-mcp**](https://github.com/StuMason/coolify-mcp) — a 42-tool MCP server that lets Claude, Cursor, and friends manage your whole Coolify estate through natural language.
+
 ![Laravel Coolify Dashboard](docs/dashboard.png)
 
 ## Why This Exists


### PR DESCRIPTION
Adds a one-line callout near the top of the README pointing readers to the sibling package **coolify-mcp**, so someone landing here discovers the MCP server too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)