### PR TITLE
fix(nginx): repeat security headers in static-asset location (completes #115)

### DIFF
--- a/src/Docker/DockerGenerator.php
+++ b/src/Docker/DockerGenerator.php
@@ -555,10 +555,16 @@ http {
             deny all;
         }
 
-        # Cache static assets
+        # Cache static assets. Any add_header in a location discards ALL
+        # inherited add_header directives, so the server-level security
+        # headers must be repeated here or static responses (including
+        # user-uploaded files under /storage) lose them.
         location ~* \\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)\$ {
             expires 1y;
             add_header Cache-Control "public, immutable";
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
             access_log off;
         }
     }

--- a/tests/Unit/Docker/DockerGeneratorTest.php
+++ b/tests/Unit/Docker/DockerGeneratorTest.php
@@ -240,6 +240,16 @@ describe('DockerGenerator common features', function () {
             ->and($content)->toContain('add_header X-Content-Type-Options "nosniff" always')
             ->and($content)->toContain('add_header X-Frame-Options "SAMEORIGIN" always')
             ->and($content)->toContain('add_header Referrer-Policy "strict-origin-when-cross-origin" always');
+
+        // nginx: an add_header inside a location discards all inherited
+        // add_header directives, so the static-asset block (which adds
+        // Cache-Control) must repeat the security headers itself.
+        $staticBlock = substr($content, strpos($content, 'location ~* \.(js|css'));
+        $staticBlock = substr($staticBlock, 0, strpos($staticBlock, '}'));
+
+        expect($staticBlock)->toContain('add_header X-Content-Type-Options "nosniff" always')
+            ->and($staticBlock)->toContain('add_header X-Frame-Options "SAMEORIGIN" always')
+            ->and($staticBlock)->toContain('add_header Referrer-Policy "strict-origin-when-cross-origin" always');
     });
 
     it('refuses commodity scanner probe paths before PHP ever runs', function () {


### PR DESCRIPTION
## Why
Follow-up to #115. nginx's `add_header` inheritance rule: if a `location` block declares **any** `add_header`, it discards *all* inherited ones. The static-asset location adds `Cache-Control`, so every js/css/png/svg/font response — including **user-uploaded files under `/storage`**, exactly where `nosniff` matters most — was served without the #115 security headers.

## What
Repeat the three security headers inside the static-asset location, with a comment explaining the nginx semantics so the next location added doesn't reintroduce the bug. Test extended to assert the headers appear inside that block specifically.

## Verification
Full pest suite green (273 passed), pint clean.

Note for release notes: like #109/#115, existing apps need to regenerate `docker/nginx.conf` to pick this up.