### PR TITLE
fix(ci): let claude-review post comments, unpin legacy model

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,6 +44,5 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model claude-opus-4-5
             --allowedTools "Bash(gh:*),Bash(npm:*),Bash(composer:*)"
             --system-prompt "You can create PRs with 'gh pr create', merge with 'gh pr merge', and comment with 'gh issue comment'. Use gh CLI for all GitHub operations."


### PR DESCRIPTION
Same two silent CI failures just fixed in claudavel (StuMason/claudavel#58):

1. **Reviews could never post** — `claude-code-review.yml` grants `pull-requests: read` / `issues: read` but the prompt instructs `gh pr comment`; a read token can't comment, so every run passed green with no review posted. Bumped to `write`.
2. **Legacy model pin** — `claude.yml` pinned `claude-opus-4-5`; dropped so the action tracks its current default and can't rot into a retired ID (as happened in claudavel with sonnet-4).

Workflow-only change, no code touched. `types: [opened]` left as-is.