### PR TITLE
chore: v3.4.0 release prep — changelog backfill, drop Laravel 11, fix version claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-07-18
+
+### Added
+- PHP 8.5 base images (`ghcr.io/stumason/laravel-coolify-base:8.5` / `8.5-node`); Node bumped to 24 in node images (#92)
+
+### Security
+- Generated nginx denies PHP execution under `/storage` and `/uploads` — a dropped `*.php` in an upload path can never reach php-fpm (#109)
+- Generated nginx hardening: `server_tokens off`, `X-Content-Type-Options` / `X-Frame-Options` / `Referrer-Policy` on all responses including errors, and refusal of commodity scanner probes (wp-login.php, xmlrpc.php, eval-stdin.php) before they boot PHP (#115)
+- Security headers repeated inside the static-asset location — nginx discards inherited `add_header` directives when a location adds its own, so cached assets (including `/storage` uploads) were missing them (#117)
+
+**Upgrade note:** the package only generates Docker files; it never rewrites existing ones. Re-run `php artisan coolify:install` (or regenerate `docker/nginx.conf`) to pick up the nginx changes above.
+
+### Fixed
+- PHP 8.5 base image builds: switched to `install-php-extensions` and split opcache into its own layer (#100, #101)
+
+### Changed
+- CI: base image rebuilds moved from nightly to fortnightly with minimal-mode caching (#107); nightly 8.5 build and spurious automerge runs fixed (#97); claude-review workflow can now actually post reviews (#118)
+
+### Removed
+- Laravel 11 from the supported constraint range — it had been untested since the CI matrix moved to 12/13. Laravel 11 apps stay on v3.3.x.
+
+## [3.3.0] - 2026-03-26
+
+### Added
+- Laravel 13 support across all illuminate dependencies
+
+## [3.2.0] - 2026-04-02
+
+### Changed
+- Dependency updates and recompiled dashboard assets
+
+## [3.1.1] - 2026-03-03
+
+### Added
+- Laravel Kick integration — health/logs/queue/artisan proxying to remote apps (#62)
+
+### Fixed
+- Batch fixes for #60, #38, #59, #67, #68 (#70)
+
+## [3.1.0] - 2026-01-23
+
 ### Added
 - Multi-environment support in dashboard with environment switcher
 - Environment badge displayed prominently in dashboard header

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Laravel package for managing Coolify infrastructure from within a Laravel application. Provides a dashboard, artisan commands, and programmatic API access - similar to how Horizon manages queues.
 
-**Stack:** PHP 8.2+, Laravel 11/12, Pest for testing
+**Stack:** PHP 8.3+, Laravel 12/13, Pest for testing
 
 ## Common Commands
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Tests](https://github.com/StuMason/laravel-coolify/actions/workflows/tests.yml/badge.svg)](https://github.com/StuMason/laravel-coolify/actions/workflows/tests.yml)
 [![Latest Version](https://img.shields.io/packagist/v/stumason/laravel-coolify.svg)](https://packagist.org/packages/stumason/laravel-coolify)
 [![PHP Version](https://img.shields.io/packagist/php-v/stumason/laravel-coolify.svg)](https://packagist.org/packages/stumason/laravel-coolify)
-[![Laravel Version](https://img.shields.io/badge/laravel-11.x%20|%2012.x-red.svg)](https://laravel.com)
+[![Laravel Version](https://img.shields.io/badge/laravel-12.x%20|%2013.x-red.svg)](https://laravel.com)
 [![License](https://img.shields.io/packagist/l/stumason/laravel-coolify.svg)](LICENSE)
 [![Downloads](https://img.shields.io/packagist/dt/stumason/laravel-coolify.svg)](https://packagist.org/packages/stumason/laravel-coolify)
 
@@ -220,8 +220,8 @@ public function boot(): void
 
 ## Requirements
 
-- PHP 8.2+
-- Laravel 11 or 12
+- PHP 8.3+
+- Laravel 12 or 13
 - Coolify 4.x instance with API access
 
 ## Testing

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": "^8.3",
-        "illuminate/contracts": "^11.0|^12.0|^13.0",
-        "illuminate/http": "^11.0|^12.0|^13.0",
-        "illuminate/support": "^11.0|^12.0|^13.0",
-        "illuminate/console": "^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^12.0|^13.0",
+        "illuminate/http": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
+        "illuminate/console": "^12.0|^13.0",
         "guzzlehttp/guzzle": "^7.5"
     },
     "require-dev": {

--- a/docs/src/content/docs/getting-started/introduction.md
+++ b/docs/src/content/docs/getting-started/introduction.md
@@ -32,8 +32,8 @@ coolify:rollback   # Rollback deployment
 
 ## Requirements
 
-- PHP 8.2+
-- Laravel 11/12
+- PHP 8.3+
+- Laravel 12/13
 - Coolify instance with API access
 - Server connected to Coolify
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -65,6 +65,6 @@ Coolify::databases()->start($uuid);
 
 ## Requirements
 
-- PHP 8.2+
-- Laravel 11 or 12
+- PHP 8.3+
+- Laravel 12 or 13
 - Coolify 4.x instance with API access


### PR DESCRIPTION
Gets the repo ready to tag **v3.4.0** (main has ~39 unreleased commits incl. the #109/#115 security hardening; note v3.3.0 has a git tag but was never published as a GitHub release).

- **CHANGELOG backfill** — entries stopped at 3.0.0 and the `[Unreleased]` block still described the multi-env work that shipped in 3.1.0. Added 3.1.0 → 3.3.0 sections from the git history and wrote the 3.4.0 section, including the *regenerate your nginx.conf* upgrade note.
- **Drop Laravel 11** from the illuminate constraints — it's been untested since the CI matrix moved to 12/13; claiming support without testing is worse than not claiming it. Laravel 11 apps simply stay on v3.3.x.
- **Version claims fixed** — README badge + requirements, docs pages, CLAUDE.md said "PHP 8.2+, Laravel 11/12" while composer requires `^8.3` and CI tests 12/13 on 8.3–8.5.

Full pest suite green after re-resolving deps against the new constraints (273 passed). Merge after #117/#118, then tag v3.4.0.