### PR TITLE
fix(client): real cache invalidation, no host-cache flush, GET-only retries

### DIFF
--- a/src/CoolifyClient.php
+++ b/src/CoolifyClient.php
@@ -13,6 +13,11 @@ use Stumason\Coolify\Exceptions\CoolifyNotFoundException;
 class CoolifyClient
 {
     /**
+     * Cache key holding the registry of keys this client has written.
+     */
+    protected const CACHE_REGISTRY = 'coolify:cache-keys';
+
+    /**
      * The base URL of the Coolify API.
      */
     protected string $baseUrl;
@@ -52,6 +57,7 @@ class CoolifyClient
     {
         if ($cached && ($ttl = config('coolify.cache_ttl', 30)) > 0) {
             $cacheKey = $this->cacheKey('get', $endpoint, $query);
+            $this->registerCacheKey($cacheKey);
 
             return Cache::remember($cacheKey, $ttl, function () use ($endpoint, $query) {
                 return $this->request('get', $endpoint, ['query' => $query]);
@@ -71,7 +77,7 @@ class CoolifyClient
      */
     public function post(string $endpoint, array $data = [], ?int $timeout = null): array
     {
-        $this->clearCacheForEndpoint($endpoint);
+        $this->clearCache();
 
         return $this->request('post', $endpoint, ['json' => $data], $timeout);
     }
@@ -86,7 +92,7 @@ class CoolifyClient
      */
     public function put(string $endpoint, array $data = []): array
     {
-        $this->clearCacheForEndpoint($endpoint);
+        $this->clearCache();
 
         return $this->request('put', $endpoint, ['json' => $data]);
     }
@@ -101,7 +107,7 @@ class CoolifyClient
      */
     public function patch(string $endpoint, array $data = []): array
     {
-        $this->clearCacheForEndpoint($endpoint);
+        $this->clearCache();
 
         return $this->request('patch', $endpoint, ['json' => $data]);
     }
@@ -115,7 +121,7 @@ class CoolifyClient
      */
     public function delete(string $endpoint): array
     {
-        $this->clearCacheForEndpoint($endpoint);
+        $this->clearCache();
 
         return $this->request('delete', $endpoint);
     }
@@ -132,7 +138,7 @@ class CoolifyClient
      */
     protected function request(string $method, string $endpoint, array $options = [], ?int $timeout = null): array
     {
-        $response = $this->buildRequest($timeout)
+        $response = $this->buildRequest($timeout, retry: $method === 'get')
             ->{$method}($this->buildUrl($endpoint), $options['json'] ?? $options['query'] ?? []);
 
         return $this->handleResponse($response);
@@ -140,12 +146,19 @@ class CoolifyClient
 
     /**
      * Build the HTTP request with authentication.
+     *
+     * Retries are GET-only: a timed-out POST to a deploy/restart endpoint
+     * may already have been acted on server-side, and retrying it fires
+     * the action again.
      */
-    protected function buildRequest(?int $timeout = null): PendingRequest
+    protected function buildRequest(?int $timeout = null, bool $retry = false): PendingRequest
     {
         $request = Http::acceptJson()
-            ->timeout($timeout ?? config('coolify.timeout', 60))
-            ->retry(3, 100, throw: false);
+            ->timeout($timeout ?? config('coolify.timeout', 60));
+
+        if ($retry) {
+            $request->retry(3, 100, throw: false);
+        }
 
         if ($this->token) {
             $request->withToken($this->token);
@@ -208,25 +221,31 @@ class CoolifyClient
     }
 
     /**
-     * Clear cached responses for an endpoint.
+     * Record a cache key in the registry so clearCache() can forget it
+     * without flushing the host application's cache store.
      */
-    protected function clearCacheForEndpoint(string $endpoint): void
+    protected function registerCacheKey(string $key): void
     {
-        // Extract the resource type from the endpoint (e.g., 'applications' from 'applications/uuid')
-        $parts = explode('/', trim($endpoint, '/'));
-        $resource = $parts[0];
+        $keys = Cache::get(self::CACHE_REGISTRY, []);
 
-        Cache::forget("coolify:{$resource}:list");
+        if (! in_array($key, $keys, true)) {
+            $keys[] = $key;
+            Cache::put(self::CACHE_REGISTRY, $keys, now()->addDay());
+        }
     }
 
     /**
      * Clear all cached Coolify responses.
+     *
+     * Only forgets keys this client wrote (tracked in a registry) — never
+     * the host application's cache. Called before every mutation so the
+     * dashboard can't serve pre-mutation state for the rest of the TTL.
      */
     public function clearCache(): void
     {
-        // This is a simple implementation - in production you might want
-        // to use cache tags if your cache driver supports them
-        Cache::flush();
+        foreach (Cache::pull(self::CACHE_REGISTRY, []) as $key) {
+            Cache::forget($key);
+        }
     }
 
     /**

--- a/tests/Unit/CoolifyClientTest.php
+++ b/tests/Unit/CoolifyClientTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Stumason\Coolify\CoolifyClient;
 use Stumason\Coolify\Exceptions\CoolifyApiException;
@@ -136,5 +137,81 @@ describe('CoolifyClient', function () {
         ]);
 
         expect($this->client->testConnection())->toBeFalse();
+    });
+});
+
+describe('CoolifyClient caching', function () {
+    // The suite-wide TestCase disables caching (cache_ttl = 0) — which is
+    // exactly why the invalidation bug shipped. Re-enable it here.
+    beforeEach(function () {
+        config(['coolify.cache_ttl' => 30]);
+        Cache::flush();
+    });
+
+    it('serves cached GETs within the TTL', function () {
+        Http::fake([
+            '*' => Http::response(['data' => ['v1']], 200),
+        ]);
+
+        $this->client->get('applications');
+        $this->client->get('applications');
+
+        Http::assertSentCount(1);
+    });
+
+    it('invalidates cached GETs after a mutation', function () {
+        Http::fake([
+            '*' => Http::response(['data' => []], 200),
+        ]);
+
+        $this->client->get('applications');
+        $this->client->post('applications/abc-123/restart');
+        $this->client->get('applications');
+
+        // GET, POST, then a fresh GET — the cached copy must not survive
+        // the mutation for the rest of the TTL.
+        Http::assertSentCount(3);
+    });
+
+    it('clearCache never touches the host application cache', function () {
+        Http::fake([
+            '*' => Http::response(['data' => []], 200),
+        ]);
+
+        Cache::put('host-app-key', 'precious', 3600);
+        $this->client->get('applications');
+
+        $this->client->clearCache();
+
+        expect(Cache::get('host-app-key'))->toBe('precious');
+    });
+});
+
+describe('CoolifyClient retries', function () {
+    it('retries failed GET requests', function () {
+        Http::fake([
+            '*' => Http::sequence()
+                ->push(['message' => 'Error'], 500)
+                ->push(['message' => 'Error'], 500)
+                ->push(['data' => []], 200),
+        ]);
+
+        $result = $this->client->get('applications', cached: false);
+
+        expect($result)->toBe(['data' => []]);
+        Http::assertSentCount(3);
+    });
+
+    it('never retries mutations', function () {
+        Http::fake([
+            '*' => Http::response(['message' => 'Error'], 500),
+        ]);
+
+        // A timed-out or failed deploy may already have been acted on
+        // server-side — retrying it would fire the deployment again.
+        expect(fn () => $this->client->post('applications/abc-123/deploy'))
+            ->toThrow(CoolifyApiException::class);
+
+        Http::assertSentCount(1);
     });
 });


### PR DESCRIPTION
Top item from the triage backlog. Three latent `CoolifyClient` bugs, all invisible because the test suite runs with `cache_ttl = 0`:

1. **Cache invalidation was a no-op.** `clearCacheForEndpoint()` forgot `coolify:{resource}:list` — a key that is *never written* (GET keys are `'coolify:'.md5(...)`). So after every deploy/restart/env mutation, the dashboard kept serving pre-mutation state for the rest of the TTL.
2. **`clearCache()` was `Cache::flush()`** — wiping the **host application's entire cache store**. Any app calling it (or hitting a mutation path that did) lost its own cache.
3. **Retries applied to POSTs.** `retry(3, 100)` on every verb means a timed-out `deploy` can fire the deployment multiple times.

### Fix
- Cached GET keys are recorded in a single registry entry (`coolify:cache-keys`, 1-day TTL). Mutations and `clearCache()` `Cache::pull` the registry and forget exactly those keys — never anything else. Any mutation clears all package keys: the cache is 30s dashboard data, so over-invalidation is free and avoids cross-resource staleness (a deploy also touches deployments lists).
- Retries are now GET-only; mutations fail fast instead of double-firing.

### Tests
5 new: cached-GET behavior, **mutation invalidates cache**, **`clearCache` leaves a host-app key untouched** (the regression that matters), GET retry behavior, **mutations never retry** (`assertSentCount(1)`). The caching tests re-enable `cache_ttl` locally since the suite-wide TestCase zeroes it — which is exactly how this shipped unseen.

Full suite: **278 passed**, Pint + PHPStan clean.