### PR TITLE
fix: correct deploy-key title quoting and drop redundant escaping

### DIFF
--- a/src/Console/ProvisionCommand.php
+++ b/src/Console/ProvisionCommand.php
@@ -1072,12 +1072,12 @@ class ProvisionCommand extends Command
         $this->line('    Adding deploy key to GitHub...');
         $publicKey = $deployKey['public_key'] ?? null;
         if ($publicKey) {
-            $escapedKey = addslashes(trim($publicKey));
+            $publicKey = trim($publicKey);
             $ghResult = Process::run(sprintf(
-                'gh api repos/%s/keys --method POST -f title="%s-deploy-key" -f key=%s -F read_only=true 2>/dev/null',
+                'gh api repos/%s/keys --method POST -f title=%s -f key=%s -F read_only=true 2>/dev/null',
                 escapeshellarg($gitRepository),
-                escapeshellarg($appName),
-                escapeshellarg($escapedKey)
+                escapeshellarg($appName.'-deploy-key'),
+                escapeshellarg($publicKey)
             ));
 
             if ($ghResult->successful()) {
@@ -1086,7 +1086,7 @@ class ProvisionCommand extends Command
                 $this->line('    <fg=yellow>Could not add deploy key via CLI. Add it manually:</>');
                 $this->line("    <fg=gray>gh api repos/{$gitRepository}/keys --method POST</> \\");
                 $this->line("      <fg=gray>-f title=\"{$appName}-deploy-key\"</> \\");
-                $this->line("      <fg=gray>-f key=\"{$escapedKey}\"</> \\");
+                $this->line("      <fg=gray>-f key=\"{$publicKey}\"</> \\");
                 $this->line('      <fg=gray>-F read_only=true</>');
                 $this->newLine();
                 if (! $this->option('no-interaction')) {


### PR DESCRIPTION
Follow-up tidy-up to #122 — two cosmetic issues spotted during review that weren't worth sending @michael-grunewalder round again for.

**1. Deploy-key title picked up literal quotes.**
`escapeshellarg($appName)` was interpolated *inside* a double-quoted title:
```
-f title="%s-deploy-key"   ->   -f title="'myapp'-deploy-key"
```
The single quotes escapeshellarg adds aren't stripped by the shell inside double quotes, so every deploy key was created named `'myapp'-deploy-key`. Now quotes the whole argument: `escapeshellarg($appName.'-deploy-key')`.

**2. Redundant `addslashes()`.** Applied to the public key before `escapeshellarg()`, which already handles quoting.

Neither affects the provisioning fixes from #122 — the `gh` call worked, the key was just badly named.

**Verified:** 278 tests pass, Pint clean, PHPStan zero errors.

Note: the parallel test run (`pest --parallel`) is flaky — two HTTP-timing tests intermittently fail under 12 processes but pass sequentially and in isolation. Unrelated to this change, but worth a look sometime.